### PR TITLE
Removing links to legacy-FT index

### DIFF
--- a/data/ftlegacy.xml
+++ b/data/ftlegacy.xml
@@ -8,6 +8,16 @@
         <orgname>The eXist Project</orgname>
     </bookinfo>
     <chapter>
+        <note>
+            <para>
+                <span class="glyphicon glyphicon-warning-sign"/>
+                <b>Important:</b>
+                <span class="glyphicon glyphicon-warning-sign"/>
+                <br/>The Legacy Full Text Index should not be used anymore. The functionaly
+                will be removed from eXist-db in a future release, because it causes instability
+                for the database. Please use the Lucene based fulltext index instead.
+            </para>
+        </note>
         <title>Legacy Full Text Index</title>
         <para>This index is used to query for a sequence of separate "words" or tokens in a longer
             stream of text. While building the index, the text is parsed into single tokens which

--- a/data/indexing.xml
+++ b/data/indexing.xml
@@ -32,13 +32,13 @@
                         </emphasis>: These map specific text nodes and attributes of the documents
                         in a collection to typed values.</para>
                 </listitem>
-                <listitem>
+                <!--listitem>
                     <para>
                         <emphasis>
                             <ulink url="ftlegacy.xml">Legacy Full Text Indexes</ulink>
                         </emphasis>These map specific text nodes and attributes of the documents in
                         a collection to text tokens.</para>
-                </listitem>
+                </listitem-->
                 <listitem>
                     <para>
                         <emphasis>
@@ -266,14 +266,14 @@
                 </varlistentry>
                 <varlistentry>
                     <term>
-                        <ulink url="lucene.xml">New Full Text Index</ulink>
+                        <ulink url="lucene.xml">Full Text Index</ulink>
                     </term>
                     <listitem>
                         <para>Faster, better configurable, more feature rich and reliable than
                             eXist-db's old index.</para>
                     </listitem>
                 </varlistentry>
-                <varlistentry>
+                <!--varlistentry>
                     <term>
                         <ulink url="ftlegacy.xml">Legacy Full Text Index</ulink>
                     </term>
@@ -281,7 +281,7 @@
                         <para>Legacy full text index. Deprecated, though still supported for backwards
                             compatibility.</para>
                     </listitem>
-                </varlistentry>
+                </varlistentry-->
                 <varlistentry>
                     <term>
                         <ulink url="devguide_indexes.xml">Spatial Index</ulink>


### PR DESCRIPTION
need to check collection.xconf.xsd as well, making sure FT is always switched off unless configured, e.g. for running test suite
