### PR TITLE
Added support for processing the 'xref' elements

### DIFF
--- a/data/lucene.xml
+++ b/data/lucene.xml
@@ -405,9 +405,9 @@ order by ft:score($sect) descending return $sect</synopsis>
                 <para>Sometimes you may want to define different Lucene indexes on the same set of elements, e.g.
                 to use a different analyzer. eXist-db allows to name a certain index using the <option>field</option>
                 attribute:</para>
-                <synopsis language="xquery"><![CDATA[<text field="title" qname="title" analyzer="en"/>]]></synopsis>
-                <para>Such an index is called <option>named index</option>. See <ulink url="#query-a-named-index">Query a Named Index</ulink> on how to query the
-                <option>named indexes</option>.</para>                
+                <synopsis language="xquery">&lt;text field="title" qname="title" analyzer="en"/&gt;</synopsis>
+                <para>Such an index is called <option>named index</option>. See <xref linkend="query-a-named-index"/> on how to query the
+                <option>named indexes</option>.</para>
             </section>
         </section>
         <section>
@@ -438,7 +438,7 @@ return $m</programlisting>
                 module.</para>
             <section id="query-a-named-index">
                 <title>Query a Named Index</title>
-                <para>To query a named index (see <ulink url="#named-indexes">Defining Fields</ulink>), use the <function>ft:query-field($fieldName, $query)</function> instead of
+                <para>To query a named index (see <xref linkend="named-indexes"/>), use the <function>ft:query-field($fieldName, $query)</function> instead of
                     <function>ft:query</function>:</para>
                 <synopsis language="xquery">ft:query-field("title", "xml")</synopsis>
                 <para>
@@ -704,11 +704,11 @@ return
                 a document, containing information which does not exist in the XML as such.</para>
             <para>The field indexes are not configured via <filename>collection.xconf</filename>. Instead we add
             fields programmatically from an XQuery (which could be run via a trigger):</para>
-            <programlisting language="xquery"><![CDATA[ft:index("/db/demo/test.xml", <doc>
-    <field name="title" store="yes">Indexing</field>
-    <field name="author" store="yes">Me</field>
-    <field name="date" store="yes">2013</field>
-</doc>)]]></programlisting>
+            <programlisting language="xquery">ft:index("/db/demo/test.xml", &lt;doc&gt;
+    &lt;field name="title" store="yes"&gt;Indexing&lt;/field&gt;
+    &lt;field name="author" store="yes"&gt;Me&lt;/field&gt;
+    &lt;field name="date" store="yes"&gt;2013&lt;/field&gt;
+&lt;/doc&gt;)</programlisting>
             <para>The <option>store</option> attribute indicates that the fields content should be stored as a string. 
                 Without this attribute, the content will be indexed for search, but you won't be able to retrieve the contents.
             </para>

--- a/modules/docbook.xql
+++ b/modules/docbook.xql
@@ -172,6 +172,8 @@ declare %private function docbook:to-html($nodes as node()*) {
                     <a href="{$node/@url}" target="_blank">{docbook:process-children($node)}</a>
                 else
                     <a href="{$node/@url}">{docbook:process-children($node)}</a>
+            case element(xref) return
+                <a href="#{$node/@linkend}">{root($node)/*//*[@id = $node/@linkend]/title/text()}</a>
             case element(note) return
                 <div class="alert alert-success">
                 {


### PR DESCRIPTION
Description of 'xref' element: http://docbook.org/tdg5/en/html/xref.html.

This element makes easier to maintain the pages, compared to 'ulink' element, as the content of the generated HTML 'a' element is generated automatically from the text content of the 'title' child element of the referenced element (which can be, for instance, a 'section' element).
