### PR TITLE
Fix for command to launch eXist as stand-alone server process.

### DIFF
--- a/data/advanced-installation.xml
+++ b/data/advanced-installation.xml
@@ -224,7 +224,7 @@ Setting admin user password...
                     <term>server.sh (Unix) / server.bat (Windows)</term>
                     <listitem>
                         <para>Enter on the command-line:</para>
-                        <synopsis>java -jar start.jar server</synopsis>
+                        <synopsis>java -jar start.jar standalone</synopsis>
                         <para>Description: Launches eXist as a stand-alone server process. In this
                             setup, eXist is only accessible through the XMLRPC and the simple,
                             built-in HTTP interface.</para>


### PR DESCRIPTION
Using "server" instead of "standalone" gives
a "java.lang.ClassNotFoundException: server" error.