### PR TITLE
Update for /db permissions part in the documentation

### DIFF
--- a/data/production_good_practice.xml
+++ b/data/production_good_practice.xml
@@ -110,9 +110,7 @@
                             <term>/db permissions</term>
                             <listitem>
                                 <para>The default permissions for /db are 0755, which should be sufficient in most cases. In the case you needed to change this, you could do that with (here for 0775):</para>
-                                <programlisting language="xquery">declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
-                                
-                                sm:chmod(xs:anyURI("/db"), "rwxrwxr-x")</programlisting>
+                                <programlisting language="xquery">sm:chmod(xs:anyURI("/db"), "rwxrwxr-x")</programlisting>
                             </listitem>
                         </varlistentry>
                     </variablelist>

--- a/data/production_good_practice.xml
+++ b/data/production_good_practice.xml
@@ -112,8 +112,7 @@
                                 <para>The default permissions for /db are 0755, which should be sufficient in most cases. In the case you needed to change this, you could do that with (here for 0775):</para>
                                 <programlisting language="xquery">declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
                                 
-                                xmldb:set-collection-permissions("/db", "admin", "dba", 509)</programlisting>
-                                <para>Please, remember the 0775 number in octal is 509, not 775. You can use util:base-to-integer(0775, 8) as argument for convenience.</para>
+                                sm:chmod(xs:anyURI("/db"), "rwxrwxr-x")</programlisting>
                             </listitem>
                         </varlistentry>
                     </variablelist>


### PR DESCRIPTION
I have just corrected this part where it was written the default permissions in eXist for /db are 0777, which is not true. It should be 0755.
