### PR TITLE
Add initial information about range index conditions

### DIFF
--- a/data/newrangeindex.xml
+++ b/data/newrangeindex.xml
@@ -239,6 +239,19 @@
                 presumably returns more hits than the name lookup. For maximum performance it may
                 thus still be faster to split the expression into two parts and do the name check
                 first.</section>
+            <section>
+                <title>Conditial combined indexes</title>
+                <para>For combined indexes, you can specify conditions to restrict the values being indexed to those contained in elements that have an attribute meeting certain criteria:<example>
+                    <title>Conditional indexes</title>
+                    <programlisting language="xml">&lt;range>
+    &lt;create qname="tei:term">
+        &lt;condition attribute="type" value="main"/>
+        &lt;field name="mainTerm" type="xs:string/>
+    &lt;/create>
+&lt;/range></programlisting>
+                </example></para>
+                <para>This will only index the value of the <code>tei:term</code> if it has an attribute named <code>type</code> with the value <code>"main"</code>.  Multiple conditions can be specified in an index definition, in which case all conditions need to match in order for the value to be indexed. <para>In order to take advantage of query optimization for conditionally indexed fields, queries should be formulated like this:<synopsis>//tei:term[@type = "main"][. = "xyz"]</synopsis><para>which then gets rewritten to a call to <synopsis>range:field(("mainTerm"), "eq", "xyz")</synopsis></para></para></para>
+            </section>
         </section>
         <section>
             <title>Using Index Functions</title>


### PR DESCRIPTION
Describes how to use conditions for complex range index config elements supported by the current eXist 3.0 code base (as introduced in exist-db/exist#1233). 

I will extend this accordingly when exist-db/exist#1252 gets merged... 