### PR TITLE
macOS name fix

### DIFF
--- a/data/advanced-installation.xml
+++ b/data/advanced-installation.xml
@@ -113,12 +113,12 @@ Setting admin user password...
             </section>
             <section id="linux">
                 <title>Unix</title>
-                <para>For Unix based systems (Linux, Mac OS X) the start/shutdown scripts can be found in
+                <para>For Unix based systems (Linux, macOS) the start/shutdown scripts can be found in
                     <filename>tools/yajsw/bin/</filename>.</para>
                 <para>The easiest way to get eXist-db started during 
                     initialization of the system is to run the following command: 
                     <synopsis>tools/yajsw/bin/installDaemon.sh</synopsis> 
-                    This works for Mac OS X and many Linux distributions.</para>
+                    This works for macOS and many Linux distributions.</para>
                 <para>
                     Please note it might be required to set some variables for the specific system, e.g. "wrapper.app.account" (to have eXist-db started as a specific user) and "wrapper.plist.template" for launchd.
                     Details can be found on the YAJSW website: <ulink url="http://yajsw.sourceforge.net/YAJSW%20Configuration%20Parameters.html">YAJSW Configuration Options</ulink>.</para>
@@ -144,7 +144,7 @@ Setting admin user password...
                             <para>Linux x86 (32bit/64bit) &amp; IA (64bit) </para>
                         </listitem>
                         <listitem>
-                            <para>Mac OS X x86 (32bit/64bit) </para>
+                            <para>macOS x86 (32bit/64bit) </para>
                         </listitem>
                         <listitem>
                             <para>Solaris x86 (32bit/64bit) &amp; SPARC (32bit/64bit)</para>

--- a/data/quickstart.xml
+++ b/data/quickstart.xml
@@ -16,7 +16,7 @@
         </section>
         <section id="system-requirements">
             <title>System Requirements</title>
-            <para>eXist-db is compatible with all recent versions of Linux, Mac OS X, and Windows.
+            <para>eXist-db is compatible with all recent versions of Linux, macOS, and Windows.
                 Out of the box, eXist-db requires at least 512 MB of RAM and about 200 MB of disk
                 space. Administrative privileges are not required to install or run eXist-db, but
                 certain installation procedures are not possible without administrative privileges.

--- a/data/troubleshooting.xml
+++ b/data/troubleshooting.xml
@@ -35,7 +35,7 @@
 06 Oct 2012 16:56:32,824 [main] INFO  (JettyStart.java [run]:129) - [eXist Build : 20121006] 
 06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:131) - [eXist Home : unknown] 
 06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:133) - [SVN Revision : 17031] 
-06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:141) - [Operating System : macOS 10.8.2 x86_64] 
+06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:141) - [Operating System : Mac OS X 10.8.2 x86_64] 
 06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:144) - [jetty.home : /Applications/eXist/tools/jetty] 
 06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:146) - [log4j.configuration : file:/Applications/eXist/log4j.xml] 
 06 Oct 2012 16:56:33,698 [main] INFO  (JettyStart.java [lifeCycleStarting]:387) - Jetty server starting... 

--- a/data/troubleshooting.xml
+++ b/data/troubleshooting.xml
@@ -23,7 +23,7 @@
                 you launched eXist-db via one of the shell scripts, the output should directly
                 appear in those.</para>
             <para>If eXist-db launched properly, you will find output similar to the following (this
-                example output is taken from Mac OS X):</para>
+                example output is taken from macOS):</para>
             <example>
                 <title>Console Output</title>
                 <screen>
@@ -35,7 +35,7 @@
 06 Oct 2012 16:56:32,824 [main] INFO  (JettyStart.java [run]:129) - [eXist Build : 20121006] 
 06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:131) - [eXist Home : unknown] 
 06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:133) - [SVN Revision : 17031] 
-06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:141) - [Operating System : Mac OS X 10.8.2 x86_64] 
+06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:141) - [Operating System : macOS 10.8.2 x86_64] 
 06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:144) - [jetty.home : /Applications/eXist/tools/jetty] 
 06 Oct 2012 16:56:32,825 [main] INFO  (JettyStart.java [run]:146) - [log4j.configuration : file:/Applications/eXist/log4j.xml] 
 06 Oct 2012 16:56:33,698 [main] INFO  (JettyStart.java [lifeCycleStarting]:387) - Jetty server starting... 
@@ -96,7 +96,7 @@ Logging already initialized. Skipping...
                     <para>
                         <envar>JAVA_HOME</envar> should point to the directory where Java—the JRE or JDK—is
                         installed. For instructions about how to set JAVA_HOME on
-                        Windows, follow the instructions in this <ulink url="http://confluence.atlassian.com/display/DOC/Setting+the+JAVA_HOME+Variable+in+Windows">guide</ulink>; on Linux, follow this <ulink url="http://www.cyberciti.biz/faq/linux-unix-set-java_home-path-variable/">guide</ulink>, and on Mac OS X, follow this <ulink url="http://www.mehtanirav.com/2008/09/02/setting-java_home-on-mac-os-x-105">guide</ulink>. </para>
+                        Windows, follow the instructions in this <ulink url="http://confluence.atlassian.com/display/DOC/Setting+the+JAVA_HOME+Variable+in+Windows">guide</ulink>; on Linux, follow this <ulink url="http://www.cyberciti.biz/faq/linux-unix-set-java_home-path-variable/">guide</ulink>, and on macOS, follow this <ulink url="http://www.mehtanirav.com/2008/09/02/setting-java_home-on-mac-os-x-105">guide</ulink>. </para>
                 </listitem>
                 <listitem>
                     <para>
@@ -106,7 +106,7 @@ Logging already initialized. Skipping...
                         example, if the <envar>EXIST_HOME</envar> path is <filename>C:\Program
                             Files\eXist</filename>, the server will look for <filename>C:\Program
                                 Files\eXist\conf.xml</filename>. You can set EXIST_HOME in the same way
-                        that you set JAVA_HOME; thus, on Mac OS X, you would enter "export
+                        that you set JAVA_HOME; thus, on macOS, you would enter "export
                         EXIST_HOME=/Applications/eXist" in the Terminal. </para>
                 </listitem>
             </itemizedlist>

--- a/data/upgrading.xml
+++ b/data/upgrading.xml
@@ -40,6 +40,26 @@
             </procedure>
         </section>
         <section>
+            <title>Upgrading to 3.0 stable</title>
+            <para>eXist-db v3.0 is not binary compatible with previous versions of eXist-db; the on-disk database file format has been updated, users should perform a full backup and restore to migrate their data.</para>
+            <para>eXist.db v3.0 and subsequent versions now require <emphasis>Java 8</emphasis>; Users must update to Java 8!</para>
+            <para>3.0 removes the the legacy Full Text Index and the  text (http://exist-db.org/xquery/text) XQuery module. Users should now look toward <code>fn:analyze-string</code>, e.g.
+                <orderedlist>
+                    <listitem>
+                        <para>instead of using <code>text:groups()</code> use <code>analyze-string()//fn:group</code>,</para>
+                    </listitem>
+                    <listitem>
+                        <para>instead of <code>text:filter("apparat", "([pr])")</code> use <code>analyze-string("apparat", "([pr])")//fn:match/string())</code>.</para>
+                    </listitem>
+                </orderedlist>                
+            </para>
+            <para>Furthermore, the SOAP APi, SOAP server, and XACML Security features were removed.</para>
+            <para>The versioning extension is now available as a separate <ulink url="https://github.com/eXist-db/xquery-versioning-module">EXPATH package</ulink></para>
+            <para>XQueryService has been moved from <code>DBBroker</code> to <code>BrokerPool</code>.</para>
+            <para>EXPath packages that incorporate Java libraries may no longer work with eXist-db v3.0 and may need to be recompiled for our API changes; packages should now explicitly specify the eXist-db versions that they are compatible with.</para>
+            <para>eXist-db v3.0 is the culmination of almost 1,500 changes. For more information on new features head to the <ulink url="http://exist-db.org/exist/apps/wiki/blogs/eXist//eXist-db-v3">blog</ulink>.</para>
+            </section>
+        <section>
             <title>Upgrading to 2.2 final</title>
             <para>The 2.2 release is not binary compatible with the 1.4.x series. You need to
                 backup/restore. If you experience problems with user logins after the restore, please restart eXist-db.</para>

--- a/data/uploading-files.xml
+++ b/data/uploading-files.xml
@@ -73,7 +73,7 @@
             <para>A WebDAV client lets you manage eXist-db database collections and documents very
                 much like directories and files in a file system—often with the full drag-and-drop
                 convenience of a desktop or file transfer client. WebDAV clients, or applications
-                with built-in WebDAV support, include Windows Explorer, Mac OS X Finder, <ulink url="http://www.webdav.org/cadaver">cadaver</ulink>, <ulink url="http://www.konqueror.org/">KDE Konqueror</ulink>, <ulink url="http://www.oxygenxml.com/">oXygen XML Editor</ulink>, <ulink url="http://www.altova.com/">XML Spy</ulink>, <ulink url="http://www.libreoffice.org/">LibreOffice</ulink>, <ulink url="http://panic.com/transmit/">Transmit</ulink> (for Mac OS X only), and many
+                with built-in WebDAV support, include Windows Explorer, macOS Finder, <ulink url="http://www.webdav.org/cadaver">cadaver</ulink>, <ulink url="http://www.konqueror.org/">KDE Konqueror</ulink>, <ulink url="http://www.oxygenxml.com/">oXygen XML Editor</ulink>, <ulink url="http://www.altova.com/">XML Spy</ulink>, <ulink url="http://www.libreoffice.org/">LibreOffice</ulink>, <ulink url="http://panic.com/transmit/">Transmit</ulink> (for macOS only), and many
                 others.</para>
             <para>To connect a WebDAV client to eXist-db, you typically need to provide the URL to
                 eXist's WebDAV interface and an eXist-db username and password. eXist-db's default

--- a/data/webdav.xml
+++ b/data/webdav.xml
@@ -22,7 +22,7 @@
             <para>eXist-db ships with a <ulink url="http://en.wikipedia.org/wiki/WebDAV">WebDAV</ulink> interface.  WebDAV makes it possible to manage database
                 collections and documents just like directories and files in a file system.  You can copy,
                 move, delete, view or edit files with any application supporting the WebDAV protocol, including Windows
-                Explorer, Mac OS X Finder, <ulink url="http://www.webdav.org/cadaver">cadaver</ulink>, <ulink url="http://www.konqueror.org/">KDE Konqueror</ulink>, <ulink url="http://www.oxygenxml.com/">oXygen XML Editor</ulink>, <ulink url="http://www.altova.com/">XML Spy</ulink>, <ulink url="http://www.libreoffice.org/">LibreOffice</ulink> and many others (see "Compatibility" below).</para>
+                Explorer, macOS Finder, <ulink url="http://www.webdav.org/cadaver">cadaver</ulink>, <ulink url="http://www.konqueror.org/">KDE Konqueror</ulink>, <ulink url="http://www.oxygenxml.com/">oXygen XML Editor</ulink>, <ulink url="http://www.altova.com/">XML Spy</ulink>, <ulink url="http://www.libreoffice.org/">LibreOffice</ulink> and many others (see "Compatibility" below).</para>
             <para>While eXist-db has had WebDAV support since version 1.0b2, the new WebDAV implementation since 
                 version 1.4.1 brings improved WebDAV compatibility, thanks to its use of the excellent open-source <ulink url="http://milton.io/">Milton</ulink> WebDAV API for Java. </para>
             <para>In the default configuration
@@ -50,8 +50,8 @@
                         serialization parameters.</para>
                 </listitem>
             </itemizedlist>
-            <para>The Milton-based WebDAV interface has been successfully tested with: Windows Web Folders (Windows XP/7), <ulink url="http://www.jscape.com/products/file-transfer-clients/anyclient/">AnyClient</ulink> (cross-platform), Mac OS X
-                Finder, <ulink url="http://www.panic.com/transmit/">Transmit</ulink> (Mac OS X), 
+            <para>The Milton-based WebDAV interface has been successfully tested with: Windows Web Folders (Windows XP/7), <ulink url="http://www.jscape.com/products/file-transfer-clients/anyclient/">AnyClient</ulink> (cross-platform), macOS
+                Finder, <ulink url="http://www.panic.com/transmit/">Transmit</ulink> (macOS), 
                 <ulink url="http://cyberduck.ch/">Cyberduck</ulink>, davfs2 version 1.4.5 (Linux),
                 OxygenXML and LibreOffice.</para>
             <para>The following clients are reported to have issues: <ulink url="http://en.wikipedia.org/wiki/GVFS">GVFS</ulink> (Nautilus) and <ulink url="http://www.netdrive.net/">NetDrive</ulink>. (Compatibility can change over time)</para>
@@ -95,8 +95,8 @@
                 </para>
             </section>
             <section id="macosx">
-                <title>Mac OS X Finder</title>
-                <para>The eXist-db database can be accessed easily with the Mac OS X Finder. First select in the Finder "Go"
+                <title>macOS Finder</title>
+                <para>The eXist-db database can be accessed easily with the macOS Finder. First select in the Finder "Go"
                     and "Connect to Server..." <screenshot>
                         <graphic fileref="resources/webdav_macosx_1.png"/>
                     </screenshot>
@@ -124,7 +124,7 @@
                         time consuming operation for large documents and for collections with many documents.</para>
                     <para>Instead it is recommended to use <ulink url="http://www.panic.com/transmit/">Transmit</ulink> or 
                         <ulink url="http://cyberduck.ch/">Cyberduck</ulink> instead.</para>
-                    <para>Note that for Mac OS X 10.8 the WebDAV client has become functional (again) in 10.8.2, but still
+                    <para>Note that for macOS 10.8 the WebDAV client has become functional (again) in 10.8.2, but still
                     the client does not work perfect, e.g. at bulk operations.</para>
                 </note>
             </section>

--- a/data/webdav.xml
+++ b/data/webdav.xml
@@ -94,7 +94,7 @@
                     </itemizedlist>
                 </para>
             </section>
-            <section id="macosx">
+            <section id="macos">
                 <title>macOS Finder</title>
                 <para>The eXist-db database can be accessed easily with the macOS Finder. First select in the Finder "Go"
                     and "Connect to Server..." <screenshot>


### PR DESCRIPTION
Since 2016  “Mac OS X” is now macOS. Please squash or rebase on merge.