### PR TITLE
Prepare v0.4.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 expath-pkg.xml
 *.xpr
+local.build.properties

--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
-eXist-db / documentation
-=============
+eXist-db Documentation
+======================
 
-This is the (official) documentation project for the eXist-db Natice XML database.
+This repository contains the official documentation for the eXist-db Native XML database and the application for browsing it.
 
-The documentation is deployed as an XAR file. The XAR file is built with "ant":
+## Resources
 
-```
-ant
-Buildfile: /Users/myhome/GitHub/documentation/build.xml
+- Browse the latest release of the documentation at http://exist-db.org/exist/apps/doc/. 
+- The documentation app is included by default in the eXist-db installer. Just go to your eXist server's Dashboard and select Documentation.
+- Update to the latest release via the eXist-db package manager or via the eXist-db.org public app repository at <http://exist-db.org/exist/apps/public-repo/>.
 
-xar:
-     [copy] Copying 1 file to /Users/myhome/GitHub/documentation
-      [zip] Building zip: /Users/myhome/GitHub/documentation/build/doc-0.3.3.xar
+## Building from source
 
-all:
+- Dependencies: Apache Ant, eXist 2.2+
+- Clone the repository to your system
+- From the command line, call `ant`
+- An EXPath Application Package (.xar file) is deposited in the `build` directory
+- Install this file via the Dashboard > Package Manager.
 
-BUILD SUCCESSFUL
-Total time: 1 second
-```
-
-Contributions are very welcome using the GitHub Pull Request mechanism.
-
-The documentation is accessible via http://exist-db.org/exist/apps/doc/ ; A pre-built version can be obtained via the eXist-db package manager or via the public App Repository http://exist-db.org/exist/apps/public-repo/  
-
+Find an area of the documentation that needs to be improved? Please raise an issue and submit a pull request!

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,7 @@
+#
+# Don't directly modify this file. Instead, copy it to local.build.properties and
+# edit that.
+#
+
+project.name=doc
+project.version=0.4.8

--- a/build.xml
+++ b/build.xml
@@ -2,8 +2,6 @@
 <project default="all" name="eXist-db Documentation">
     <property file="local.build.properties"/>
     <property file="build.properties"/>
-    <property name="project.app" value="doc"/>
-    <property name="project.version" value="0.4.7"/>
     <property name="build" value="build"/>
     <property name="data" value="data"/>
     <property name="server.url" value="http://demo.exist-db.org/exist/apps/public-repo/public/"/>
@@ -23,10 +21,11 @@
         <mkdir dir="${build}"/>
         <copy file="expath-pkg.xml.tmpl" tofile="expath-pkg.xml" filtering="true" overwrite="true">
             <filterset>
+                <filter token="project.name" value="${project.name}"/>
                 <filter token="project.version" value="${project.version}"/>
             </filterset>
         </copy>
-        <zip basedir="." destfile="${build}/${project.app}-${project.version}${git.commit}.xar">
+        <zip basedir="." destfile="${build}/${project.name}-${project.version}${git.commit}.xar">
             <exclude name="${build}/*"/>
             <exclude name=".git*"/>
             <exclude name="*.tmpl"/>
@@ -37,7 +36,7 @@
         <input message="Enter password:" addproperty="server.pass" defaultvalue="">
             <handler type="secure"/>
         </input>
-        <property name="xar" value="${project.app}-${project.version}${git.commit}.xar"/>
+        <property name="xar" value="${project.name}-${project.version}${git.commit}.xar"/>
         <exec executable="curl">
             <arg line="-T ${build}/${xar} -u admin:${server.pass} ${server.url}/${xar}"/>
         </exec>

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/doc" abbrev="doc" version="@project.version@" spec="1.0">
+<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/doc" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>eXist-db Documentation</title>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.4.0"/>
 </package>

--- a/repo.xml
+++ b/repo.xml
@@ -3,7 +3,7 @@
     <repo:description>eXist 2.0 documentation application.</repo:description>
     <repo:author>Joe Wicentowski</repo:author>
     <repo:author>Wolfgang Meier</repo:author>
-    <repo:website/>
+    <repo:website>https://github.com/eXist-db/documentation</repo:website>
     <repo:status>alpha</repo:status>
     <repo:license>GNU-LGPL</repo:license>
     <repo:copyright>true</repo:copyright>
@@ -12,6 +12,23 @@
     <repo:prepare>pre-install.xql</repo:prepare>
     <repo:finish/>
     <repo:permissions user="admin" password="" group="dba" mode="rw-rw-r--"/>
-    <note>When upgrading, please make sure you also updated the shared-resources package to > 0.4.0.</note>
+    <note>Note for users of eXist 2.x: When upgrading, please make sure you also updated the shared-resources package to > 0.4.0.</note>
+    <changelog>
+        <change version="0.4.7">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>No release notes prepared for this or any earlier versions.</li>
+            </ul>
+        </change>
+        <change version="0.4.8">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>[New Range Index]: Added full documentation for "conditional indexes," a new feature for limiting indexed values to elements meeting certain child attribute criteria.</li>
+                <li>[Quick Start]: Added a workaround for those with Saxon installed as a JRE extension; improved description of macOS first run &amp; default data directory location.</li>
+                <li>[Upgrading]: Added new section on how to upgrade to eXist 3.0 and important changes in this release.</li>
+                <li>[XQSuite]: Added descriptions of %test:stats and %test:assertXPath annotations.</li>
+                <li>[Lucene]: Fixed WhitespaceAnalyzer classname and the version of Lucene.</li>
+                <li>Across the board: Fixed name of macOS (was Mac OS X); reviewed mentions of v2.0 and updated where appropriate to match current release</li>
+            </ul>
+        </change>
+    </changelog>
     <deployed>2013-05-26T15:18:37.268+02:00</deployed>
 </repo:meta>


### PR DESCRIPTION
As proposed in #96:

- Adopt conventions for app name and version properties
- Add release notes describing which articles had improvements and what those improvements were (drawn from commit history) so users know what to look out for
- Add github repo as repo website link
- Revise note shown during upgrade to indicate it is only a concern for eXist 2.x users
- Improve README