### PR TITLE
Fixed external link to cron trigger site and one internal link

### DIFF
--- a/data/backup.xml
+++ b/data/backup.xml
@@ -171,7 +171,7 @@
                     starting at midnight. The time/frequency of the backup is specified in the
                     <option>cron-trigger</option> attribute. The syntax is borrowed from the
                     Unix cron utility, though there are small differences. Please consult the Quartz
-                    documentation about <ulink url="http://www.opensymphony.com/quartz/wikidocs/TutorialLesson6.html">CronTrigger</ulink> configuration.</para>
+                    documentation about <ulink url="http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-06.html">CronTrigger</ulink> configuration.</para>
                 <para>The task accepts the following parameters:</para>
                 <variablelist>
                     <varlistentry>
@@ -521,7 +521,7 @@ repair:repair()]]></programlisting>
                 straightforward within eXide. Either use:</para>
             <itemizedlist>
                 <listitem>
-                    <para>the <ulink url="development-starter.xml#synchronize">synchronize
+                    <para>the <ulink url="development-starter.xml#D1.4.16">synchronize
                             feature</ulink> to write the package contents to a directory on disk,
                         or</para>
                 </listitem>


### PR DESCRIPTION
Also, at the same page exist/apps/doc/build/doc-0.4.8/backup.xml at the paragraph 

>**Scheduling Backups and Consistency Checks**

>The core class for the server-side backup as well as consistency checks is called ConsistencyCheckTask. It can be registered as a system task with eXist-db's scheduler. 

Link with the text _scheduler_ has wrong anchor
http://localhost:8888/exist/apps/doc/build/doc-0.4.8/configuration.xml#N104CF