### PR TITLE
Changed broken relative javadocs links with absolute ones

### DIFF
--- a/data/devguide_soap.xml
+++ b/data/devguide_soap.xml
@@ -39,8 +39,8 @@
             <para>while the second is available on:</para>
             <synopsis format="linespecific">http://localhost:8080/exist/services/Admin</synopsis>
             <para>Both services are described in the Java docs regarding their interfaces. Visit:
-                    <ulink url="api/org/exist/soap/Query.html">org.exist.soap.Query</ulink> and
-                    <ulink url="api/org/exist/soap/Admin.html">org.exist.soap.Admin</ulink> for more
+                    <ulink url="http://exist-db.org/api/org/exist/soap/Query.html">org.exist.soap.Query</ulink> and
+                    <ulink url="http://exist-db.org/api/org/exist/soap/Admin.html">org.exist.soap.Admin</ulink> for more
                 information.</para>
             <para>The following SOAP example (available at:
                     <filename>samples/org/exist/examples/soap/GetDocument.java</filename>)

--- a/data/devguide_xmldb.xml
+++ b/data/devguide_xmldb.xml
@@ -23,7 +23,7 @@
                 databases and supports the development of portable, reusable applications. eXist's
                 implementation of the XML:DB standards follows the Xindice implementation, and
                 conforms to the latest working drafts put forth by the <ulink url="http://xmldb-org.sourceforge.net/xapi/">XML:DB Initiative</ulink>. For more
-                information, refer to the <ulink url="api/index.html">Javadocs for this API</ulink>.</para>
+                information, refer to the <ulink url="http://exist-db.org/api/index.html">Javadocs for this API</ulink>.</para>
             <para>The basic components employed by the XML:DB API are <emphasis>drivers</emphasis>,
                     <emphasis>collections</emphasis>, <emphasis>resources</emphasis> and
                     <emphasis>services</emphasis>.</para>
@@ -407,19 +407,19 @@ public class StoreExample {
                 <title>Additional Services</title>
                 <para>eXist provides several services in addition to those defined by the XML:DB
                     specification:</para>
-                <para>The <ulink url="api/org/exist/xmldb/UserManagementService.html">UserManagementService</ulink> service contains methods to manage users and
+                <para>The <ulink url="http://exist-db.org/api/org/exist/xmldb/UserManagementService.html">UserManagementService</ulink> service contains methods to manage users and
                     handle permissions. These methods resemble common Unix commands such as
                         <methodname>chown</methodname> or <methodname>chmod</methodname>. As with
                     other services, <classname>UserManagementService</classname> can be retrieved
                     from a collection object, as in:</para>
                 <synopsis format="linespecific">UserManagementService service = 
                     (UserManagementService)collection.getService("UserManagementService", "1.0");</synopsis>
-                <para>Another service called <ulink url="api/org/exist/xmldb/DatabaseInstanceManager.html">DatabaseInstanceManager</ulink>, provides a single method to shut down the
+                <para>Another service called <ulink url="http://exist-db.org/api/org/exist/xmldb/DatabaseInstanceManager.html">DatabaseInstanceManager</ulink>, provides a single method to shut down the
                     database instance accessed by the driver. You have to be a member of the
                         <option>dba</option> user group to use this method or an exception will be
-                    thrown. See the <ulink url="deployment.xml#embedded">Deployment Guide</ulink>
+                    thrown. See the <ulink url="deployment.xml#D2.4.12">Deployment Guide</ulink>
                     for an example.</para>
-                <para>Finally, interface <ulink url="api/org/exist/xmldb/IndexQueryService.html">IndexQueryService</ulink> supports access to the terms and elements
+                <para>Finally, interface <ulink url="http://exist-db.org/api/org/exist/xmldb/IndexQueryService.html">IndexQueryService</ulink> supports access to the terms and elements
                     contained in eXist's internal index. Method getIndexedElements() returns a list
                     of element occurrences for the current collection. For each occurring element,
                     the element's name and a frequency count is returned.</para>

--- a/data/devguide_xmlrpc.xml
+++ b/data/devguide_xmlrpc.xml
@@ -190,7 +190,7 @@ sub process {
             <title>XML-RPC: Available Methods</title>
             <para>This section gives you an overview of the methods implemented by the eXist XML-RPC
                 server. Only the most common methods are presented here. For a complete list see the
-                Java interface <ulink url="api/org/exist/xmlrpc/RpcAPI.html">RpcAPI.java</ulink>.
+                Java interface <ulink url="http://exist-db.org/api/org/exist/xmlrpc/RpcAPI.html">RpcAPI.java</ulink>.
                 Note that the method signatures are presented below using Java data types. Also note
                 that some methods like <methodname>getDocument()</methodname> and
                     <methodname>retrieve()</methodname> accept a struct to specify optional output
@@ -890,7 +890,7 @@ sub process {
                                 <listitem>
                                     <para>The permissions assigned to the resource, which can be
                                         specified either as an integer value constructed using the
-                                            <ulink url="api/org/exist/security/Permission">Permission</ulink> class, or using a modification
+                                            <ulink url="http://exist-db.org/api/org/exist/security/Permission.html">Permission</ulink> class, or using a modification
                                         string. The bit encoding of the integer value corresponds to
                                         Unix conventions. The modification string has the following
                                         syntax:</para>

--- a/data/xquery.xml
+++ b/data/xquery.xml
@@ -766,7 +766,7 @@ return $w</synopsis>
                     methods are defined in <classname>
                         <ulink url="http://download.oracle.com/javase/6/docs/api/javax/xml/transform/OutputKeys.html">javax.xml.transform.OutputKeys</ulink>
                     </classname> and <classname>
-                        <ulink url="api/org/exist/storage/serializers/EXistOutputKeys.html">EXistOutputKeys</ulink>
+                        <ulink url="http://exist-db.org/api/org/exist/storage/serializers/EXistOutputKeys.html">EXistOutputKeys</ulink>
                     </classname>. The latter eXist-specific options include the following:</para>
                 <variablelist>
                     <varlistentry>


### PR DESCRIPTION
I don't know if javadocs for exist api are supposed to be a part of the Documentation app, but at this point it is not a case. So I have changed those broken relative links with the absolute ones that point to the online version of the api javadocs.