### PR TITLE
Add parser paragraph

### DIFF
--- a/src/main/xar-resources/data/production_good_practice/listings/listing-3.xml
+++ b/src/main/xar-resources/data/production_good_practice/listings/listing-3.xml
@@ -1,0 +1,12 @@
+<parser>
+        <xml>
+
+            <features>
+
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+
+            </features>
+        </xml>
+</parser>

--- a/src/main/xar-resources/data/production_good_practice/production_good_practice.xml
+++ b/src/main/xar-resources/data/production_good_practice/production_good_practice.xml
@@ -234,7 +234,7 @@
         unlikely to require the WebDAV or SOAP Admin features for operation in a live environment.
         These and other services can be disabled easily.</para>
       <para>Means for anonymous users to execute arbitrary code require special attention. There are
-        two means of code execution in eXist, which make sense during development, but should be
+        three means of code execution in eXist, which make sense during development, but should be
         reconsidered for production systems:</para>
       <variablelist spacing="compact">
         <varlistentry>
@@ -247,22 +247,11 @@
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>Parser</term>
+          <term>XML external entities</term>
           <listitem>
             <para>In order to ensure a secure environment, the <literal>external-general-entities</literal>, <literal>external-parameter-entities</literal>, 
             and <literal>secure-processing</literal> feature flags should be set in <literal>conf.xml</literal>:</para>
-            <programlisting language="xml">
-                    
-                &lt;parser&gt;
-                        &lt;xml&gt;
-                            &lt;features&gt; 
-                &lt;feature name="http://xml.org/sax/features/external-general-entities" value="false"/&gt;
-                &lt;feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/&gt;
-                &lt;feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/&gt;
-          &lt;/features&gt;
-                  &lt;/xml&gt; 
-                  &lt;/parser&gt; 
-           </programlisting>
+            <programlisting language="xml" xlink:href="listings/listing-3.xml"/>
            </listitem>
         </varlistentry>
         <varlistentry>

--- a/src/main/xar-resources/data/production_good_practice/production_good_practice.xml
+++ b/src/main/xar-resources/data/production_good_practice/production_good_practice.xml
@@ -251,10 +251,19 @@
           <listitem>
             <para>In order to ensure a secure environment, the <literal>external-general-entities</literal>, <literal>external-parameter-entities</literal>, 
             and <literal>secure-processing</literal> feature flags should be set in <literal>conf.xml</literal>:</para>
-            <programlisting language="xml">&lt;feature name="http://xml.org/sax/features/external-general-entities" value="false"/&gt;
+            <programlisting language="xml">
+                    
+                &lt;parser&gt;
+                        &lt;xml&gt;
+                            &lt;features&gt; 
+                &lt;feature name="http://xml.org/sax/features/external-general-entities" value="false"/&gt;
                 &lt;feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/&gt;
                 &lt;feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/&gt;</programlisting>
-          </listitem>
+          &lt;/features&gt;
+                  &lt;/xml&gt; 
+                  &lt;/parser&gt; 
+                
+           </listitem>
         </varlistentry>
         <varlistentry>
           <term>REST server</term>

--- a/src/main/xar-resources/data/production_good_practice/production_good_practice.xml
+++ b/src/main/xar-resources/data/production_good_practice/production_good_practice.xml
@@ -247,6 +247,16 @@
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term>Parser</term>
+          <listitem>
+            <para>In order to ensure a secure environment, the <literal>external-general-entities</literal>, <literal>external-parameter-entities</literal>, 
+            and <literal>secure-processing</literal> feature flags should be set in <literal>conf.xml</literal>:</para>
+            <programlisting language="xml">&lt;feature name="http://xml.org/sax/features/external-general-entities" value="false"/&gt;
+                &lt;feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/&gt;
+                &lt;feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/&gt;</programlisting>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term>REST server</term>
           <listitem>
             <para>We recommend to prevent eXist's REST server from directly receiving web requests,

--- a/src/main/xar-resources/data/production_good_practice/production_good_practice.xml
+++ b/src/main/xar-resources/data/production_good_practice/production_good_practice.xml
@@ -258,11 +258,11 @@
                             &lt;features&gt; 
                 &lt;feature name="http://xml.org/sax/features/external-general-entities" value="false"/&gt;
                 &lt;feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/&gt;
-                &lt;feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/&gt;</programlisting>
+                &lt;feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/&gt;
           &lt;/features&gt;
                   &lt;/xml&gt; 
                   &lt;/parser&gt; 
-                
+           </programlisting>
            </listitem>
         </varlistentry>
         <varlistentry>


### PR DESCRIPTION
I've added the

```
<feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
<feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
<feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
```

instruction to the `<parser>` section.