### PR TITLE
remove fn:contains-token from the list of unsupported functions

### DIFF
--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -122,9 +122,6 @@
                     <para> <literal>fn:collation-key#1, #2</literal> </para>
                 </listitem>
                 <listitem>
-                    <para> <literal>fn:contains-token#2, #3</literal> </para>
-                </listitem>
-                <listitem>
                     <para> <literal>fn:default-language#0</literal> </para>
                 </listitem>
                 <listitem>


### PR DESCRIPTION
result of https://github.com/eXist-db/exist/pull/2792