### PR TITLE
doc: remove fn:parse-ietf-date from unsupported functions

### DIFF
--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -140,9 +140,6 @@
                     <para> <literal>fn:nilled#0</literal> </para>
                 </listitem>
                 <listitem>
-                    <para> <literal>fn:parse-ietf-date#1</literal> </para>
-                </listitem>
-                <listitem>
                     <para> <literal>fn:path#0, #1</literal> </para>
                 </listitem>
                 <listitem>


### PR DESCRIPTION
update documentation for https://github.com/eXist-db/exist/pull/2857