### PR TITLE
doc: remove fn:xml-to-json#1, #2 from unsupported functions

### DIFF
--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -149,9 +149,6 @@
                     <para> <literal>fn:uri-collection#0, #1</literal> </para>
                 </listitem>
                 <listitem>
-                    <para> <literal>fn:xml-to-json#1, #2</literal> </para>
-                </listitem>
-                <listitem>
                     <para> <literal>map:find#2</literal> </para>
                 </listitem>
                 <listitem>

--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -57,6 +57,35 @@
 
         <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
+        <sect2 xml:id="partially-supported-features">
+            <title>Partially Supported Features</title>
+
+            <para>eXist-db has partial support for following xQuery functions</para>
+            <itemizedlist>
+              <listitem>
+                <para><link condition="_blank"
+                    xlink:href="https://www.w3.org/TR/xpath-functions-31/#func-xml-to-json">
+                    fn:xml-to-json()
+                  </link></para>
+                <para>needs implementation</para>
+                  <para>not ignore options map</para>
+                  <para>for xml strings that are marked as beeing escaped</para>
+                    <para>any unescaped occurrence of quotation mark, backspace, form-feed, newline,
+                      carriage return, tab, or solidus is replaced by \", \b, \f, \n, \r, \t, or \/
+                      respectively</para>
+                    <para>any other codepoint in the range 1-31 or 127-159 is replaced by an escape
+                      in the form \uHHHH where HHHH is the upper-case hexadecimal representation of
+                      the codepoint value</para>
+                  <para>for xml strings that are not marked as beeing escaped</para>
+                    <para>any other codepoint in the range 1-31 or 127-159 is replaced by an escape
+                      in the form \uHHHH where HHHH is the upper-case hexadecimal representation of
+                      the codepoint value</para>
+              </listitem>
+            </itemizedlist>
+        </sect2>
+
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
         <sect2 xml:id="unsupported-features">
             <title>Unsupported features</title>
 

--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -67,17 +67,13 @@
                     xlink:href="https://www.w3.org/TR/xpath-functions-31/#func-xml-to-json">
                     fn:xml-to-json()
                   </link>
-                    implements handling of xml null, xml boolean, xml number, xml array and xml
-                    map elements according to specification.
-                    fn:xml-to-json() implements handling of xml strings and xml map keys that are not
-                    mentioned below according to specification. It ignores the options map.
-                    fn:xml-to-json() is missing implementation for replacing codepoints in the range
-                    1-31 or 127-159 by escaped unicode representations of the codepoint value for any
-                    xml string or map key.
-                    In addition to that for xml strings and map keys that are marked as beeing escaped
-                    fn:xml-to-json() is missing implementation to replace any unescaped occurrence of
-                    quotation mark, backspace, form-feed, newline, carriage return, tab, or solidus
-                    by \&quot;, \b, \f, \n, \r, \t, or \/ respectively.
+                    handles most valid input according to specification. Notable exceptions follow.
+                    <literal>fn:xml-to-json()</literal> does not replace codepoints in the range
+                    <literal>1-31</literal> or <literal>127-159</literal> in any
+                    string or map key.
+                    Additionally for strings and map keys that are marked as beeing escaped
+                    <literal>fn:xml-to-json()</literal> does not replace any unescaped occurrence of
+                    quotation mark, backspace, form-feed, newline, carriage return, tab, or solidus.
                 </para>
               </listitem>
             </itemizedlist>

--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -71,7 +71,7 @@
                     <literal>fn:xml-to-json()</literal> does not replace codepoints in the range
                     <literal>1-31</literal> or <literal>127-159</literal> in any
                     string or map key.
-                    Additionally for strings and map keys that are marked as beeing escaped
+                    Additionally for strings and map keys that are marked as being escaped
                     <literal>fn:xml-to-json()</literal> does not replace any unescaped occurrence of
                     quotation mark, backspace, form-feed, newline, carriage return, tab, or solidus.
                 </para>

--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -5,7 +5,7 @@
     xmlns:xlink="http://www.w3.org/1999/xlink">
     <info>
         <title>XQuery in eXist-db</title>
-        <date>4Q19</date>
+        <date>2Q19</date>
         <keywordset>
             <keyword>xquery</keyword>
         </keywordset>
@@ -53,30 +53,6 @@
                 <literal>following-sibling::</literal>, <literal>preceding::</literal> and
                 <literal>preceding-sibling::</literal>. The only optional axis not supported is the
                 <literal>namespace</literal> axis.</para>
-        </sect2>
-
-        <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-        <sect2 xml:id="partially-supported-features">
-            <title>Partially Supported Features</title>
-
-            <para>eXist-db has partial support for following xQuery functions:</para>
-            <itemizedlist>
-              <listitem>
-                <para><link condition="_blank"
-                    xlink:href="https://www.w3.org/TR/xpath-functions-31/#func-xml-to-json">
-                    fn:xml-to-json()
-                  </link>
-                    handles most valid input according to specification. Notable exceptions follow.
-                    <literal>fn:xml-to-json()</literal> does not replace codepoints in the range
-                    <literal>1-31</literal> or <literal>127-159</literal> in any
-                    string or map key.
-                    Additionally for strings and map keys that are marked as being escaped
-                    <literal>fn:xml-to-json()</literal> does not replace any unescaped occurrence of
-                    quotation mark, backspace, form-feed, newline, carriage return, tab, or solidus.
-                </para>
-              </listitem>
-            </itemizedlist>
         </sect2>
 
         <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->

--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -5,7 +5,7 @@
     xmlns:xlink="http://www.w3.org/1999/xlink">
     <info>
         <title>XQuery in eXist-db</title>
-        <date>2Q19</date>
+        <date>4Q19</date>
         <keywordset>
             <keyword>xquery</keyword>
         </keywordset>
@@ -60,26 +60,25 @@
         <sect2 xml:id="partially-supported-features">
             <title>Partially Supported Features</title>
 
-            <para>eXist-db has partial support for following xQuery functions</para>
+            <para>eXist-db has partial support for following xQuery functions:</para>
             <itemizedlist>
               <listitem>
                 <para><link condition="_blank"
                     xlink:href="https://www.w3.org/TR/xpath-functions-31/#func-xml-to-json">
                     fn:xml-to-json()
-                  </link></para>
-                <para>needs implementation</para>
-                  <para>not ignore options map</para>
-                  <para>for xml strings that are marked as beeing escaped</para>
-                    <para>any unescaped occurrence of quotation mark, backspace, form-feed, newline,
-                      carriage return, tab, or solidus is replaced by \", \b, \f, \n, \r, \t, or \/
-                      respectively</para>
-                    <para>any other codepoint in the range 1-31 or 127-159 is replaced by an escape
-                      in the form \uHHHH where HHHH is the upper-case hexadecimal representation of
-                      the codepoint value</para>
-                  <para>for xml strings that are not marked as beeing escaped</para>
-                    <para>any other codepoint in the range 1-31 or 127-159 is replaced by an escape
-                      in the form \uHHHH where HHHH is the upper-case hexadecimal representation of
-                      the codepoint value</para>
+                  </link>
+                    implements handling of xml null, xml boolean, xml number, xml array and xml
+                    map elements according to specification.
+                    fn:xml-to-json() implements handling of xml strings and xml map keys that are not
+                    mentioned below according to specification. It ignores the options map.
+                    fn:xml-to-json() is missing implementation for replacing codepoints in the range
+                    1-31 or 127-159 by escaped unicode representations of the codepoint value for any
+                    xml string or map key.
+                    In addition to that for xml strings and map keys that are marked as beeing escaped
+                    fn:xml-to-json() is missing implementation to replace any unescaped occurrence of
+                    quotation mark, backspace, form-feed, newline, carriage return, tab, or solidus
+                    by \&quot;, \b, \f, \n, \r, \t, or \/ respectively.
+                </para>
               </listitem>
             </itemizedlist>
         </sect2>


### PR DESCRIPTION
Update documentation for https://github.com/eXist-db/exist/pull/3141