### PR TITLE
Old map constructor syntax was removed in 5.0.0

### DIFF
--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -943,13 +943,6 @@
                     the specification.</para>
             </listitem>
             <listitem>
-                <para>Map notation: During the drafting of XQuery 3.0, the specification changed
-                    slightly and so did the implementation in eXist-db. To keep backwards
-                    compatibility, eXist allows the older notation in map constructors:
-                    <code>key:=value</code> in addition to the new one, <code>key:
-                    value</code>.</para>
-            </listitem>
-            <listitem>
                 <para>Serialization: Certain <link xlink:href="#legacy-serialization">Legacy
                     Serialization Parameters</link>.</para>
             </listitem>


### PR DESCRIPTION
Just a minor update. The legacy map constructor syntax was removed in https://github.com/eXist-db/exist/pull/2890.