### PR TITLE
Add documentation for backup client flag --use-ssl

### DIFF
--- a/src/main/xar-resources/data/backup/backup.xml
+++ b/src/main/xar-resources/data/backup/backup.xml
@@ -431,7 +431,7 @@
             </itemizedlist>
             <para>For example, to backup the entire database on a Unix system to the target
                 directory <literal>/var/backup/hd060501</literal>, enter the following:</para>
-            <programlisting></programlisting>
+            <programlisting>bin/backup.sh -u admin -p admin-pass -b /db -d /var/backup/hd060501</programlisting>
 
             <para>By default, the utility connects to the database at the URI:
                 <literal>xmldb:exist://localhost:8080/exist/xmlrpc</literal>. If you want to backup

--- a/src/main/xar-resources/data/backup/backup.xml
+++ b/src/main/xar-resources/data/backup/backup.xml
@@ -431,7 +431,7 @@
             </itemizedlist>
             <para>For example, to backup the entire database on a Unix system to the target
                 directory <literal>/var/backup/hd060501</literal>, enter the following:</para>
-            <programlisting>bin/backup.sh -u admin -p admin-pass -b /db -d /var/backup/hd060501</programlisting>
+            <programlisting></programlisting>
 
             <para>By default, the utility connects to the database at the URI:
                 <literal>xmldb:exist://localhost:8080/exist/xmlrpc</literal>. If you want to backup
@@ -442,6 +442,11 @@
             <programlisting xlink:href="listings/listing-9.txt"/>
             <para>Default settings for the user, password or server URIs can also be set in the
                 <literal>backup.properties</literal> file.</para>
+            <para>If you want to connect to a databse using SSL, use the parameter <literal>--use-ssl</literal> or
+                (shorter) <literal>-S</literal>:</para>
+            <programlisting xlink:href="listings/listing-12.txt"/>
+            <para>NOTE: You still have to set the correct port (usually port 443), otherwise the client will attempt
+                SSL to port 8080.</para>
         </sect2>
 
     </sect1>

--- a/src/main/xar-resources/data/backup/listings/listing-12.txt
+++ b/src/main/xar-resources/data/backup/listings/listing-12.txt
@@ -1,0 +1,2 @@
+bin/backup.sh -u admin -p admin-pass --use-ssl
+                -ouri=xmldb:exist://example.org:443/exist/xmlrpc -b /db

--- a/src/main/xar-resources/data/backup/listings/listing-7.txt
+++ b/src/main/xar-resources/data/backup/listings/listing-7.txt
@@ -3,6 +3,9 @@ backup.sh --h
     Usage: backup.sh [Arguments]
     
     Arguments:
+    -a, --overwrite-apps                       overwrite newer applications
+                                               installed in the database.
+                                               Default: disabled
     -b, --backup <string>                      backup the specified collection.
                                                <string>: any string
                                                Default:
@@ -39,6 +42,9 @@ backup.sh --h
                                                Default: /Users/aretter/code/exist.maven/.
     -R, --rebuild                              rebuild the EXpath app repository
                                                after restore.
+                                               Default: disabled
+    -S, --use-ssl                              Use SSL by default for remote
+                                               connections
                                                Default: disabled
     -u, --user <string>                        set user.
                                                <string>: any string


### PR DESCRIPTION
Add a short paragraph documenting the use of `--use-ssl` for the backup client (see <https://github.com/eXist-db/exist/issues/3434>).