### PR TITLE
Update xquery.xml - allowing empty

### DIFF
--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -106,9 +106,6 @@
                 <listitem>
                     <para>"count" clause</para>
                 </listitem>
-                <listitem>
-                    <para>"allowing empty" clause</para>
-                </listitem>
             </itemizedlist>
 
             <para>eXist-db supports all standard XQuery functions except for the following:</para>


### PR DESCRIPTION
The FLWOR expression's `allowing empty` keywords (see [spec](https://www.w3.org/TR/xquery-31/#id-xquery-for-clause)) have been actually been supported since https://github.com/eXist-db/exist/pull/763 (commit https://github.com/eXist-db/exist/commit/b0e9eb5faa20374c4460bd7ada23464c78e02d2c), released with eXist 3.0.