### PR TITLE
Add -Ddocker.tag to documentation

### DIFF
--- a/src/main/xar-resources/data/exist-building/exist-building.xml
+++ b/src/main/xar-resources/data/exist-building/exist-building.xml
@@ -211,6 +211,14 @@
           </row>
           <row>
             <entry>
+              <para><code>-Ddocker.tag=tag-name</code></para>
+            </entry>
+            <entry>
+              <para>Tags the built eXist-db Docker image with a specific tagname.</para>
+            </entry>
+          </row>
+          <row>
+            <entry>
               <para><code>-Dmac.signing=true</code></para>
             </entry>
             <entry>


### PR DESCRIPTION
Adds a line to the build configuration options, with `-Ddocker.tag` as it is really useful to distinguish your builds from the official ones.