### PR TITLE
Add pointer to range:matches in documentation of new range index

### DIFF
--- a/src/main/xar-resources/data/newrangeindex/newrangeindex.xml
+++ b/src/main/xar-resources/data/newrangeindex/newrangeindex.xml
@@ -49,9 +49,11 @@
             string functions like <code>fn:contains</code>, <code>fn:starts-with</code>,
             <code>fn:ends-with</code>. </para>
         <note>
-            <para> <code>fn:matches</code> is currently not supported due to limitations in Lucene's
-                regular expression handling. If you require fn:matches a lot, consider using the
-                <link xlink:href="oldrangeindex">old range index</link>.</para>
+            <para><code>fn:matches</code> is currently not supported due to limitations in Lucene's
+                regular expression handling. Alternatives include the new <code>range:matches</code>
+                function (which <emphasis>is</emphasis> supported with the new range index, although subject to
+                <link condition="_blank" xlink:href="http://lucene.apache.org/core/4_5_1/core/org/apache/lucene/util/automaton/RegExp.html">Lucene 
+                    limitations</link>) and the <link xlink:href="oldrangeindex">old range index</link> (which does not use Lucene).</para>
         </note>
         <para>Above configuration applies to documents using MODS, a standard for bibliographical
             metadata. The following XPath expressions use the created indexes: </para>

--- a/src/main/xar-resources/data/newrangeindex/newrangeindex.xml
+++ b/src/main/xar-resources/data/newrangeindex/newrangeindex.xml
@@ -52,7 +52,7 @@
             <para><code>fn:matches</code> is currently not supported due to limitations in Lucene's
                 regular expression handling. Alternatives include the new <code>range:matches</code>
                 function (which <emphasis>is</emphasis> supported with the new range index, although subject to
-                <link condition="_blank" xlink:href="http://lucene.apache.org/core/4_5_1/core/org/apache/lucene/util/automaton/RegExp.html">Lucene 
+                <link condition="_blank" xlink:href="https://lucene.apache.org/core/4_10_4/core/org/apache/lucene/util/automaton/RegExp.html">Lucene 
                     limitations</link>) and the <link xlink:href="oldrangeindex">old range index</link> (which does not use Lucene).</para>
         </note>
         <para>Above configuration applies to documents using MODS, a standard for bibliographical


### PR DESCRIPTION
This adds a pointer to range:matches as an alternative to fn:matches with the new range index (subject to Lucene limitation). 

Possible improvement that was beyond my ability: I copied the pointer to the Lucene documentation from some earlier eXist-db documentation, but the Lucene page in question is written for Java developers, and it is not likely to be intelligible to eXist-db users who need to know, without formal grammar productions or Java code, which common regex features cannot be used with the new range index. I was not able to find a clear statement of this in plain language either on the eXist-db site or in any Lucene documentation, and I was not confident about whether I understood the limitations well enough to write it myself. Might someone who knows the details be able to summarize them here or point to a plain-language explanation elsewhere?