### PR TITLE
Test built package in Integration Test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <project.build.target>1.8</project.build.target>
 
     <exist.version>5.3.0-SNAPSHOT</exist.version>
+    <shared-resources.version>0.8.2</shared-resources.version>
     <node.version>v10.22.1</node.version>
     <npm.version>6.14.6</npm.version>
 
@@ -251,6 +252,53 @@
       </plugin>
       <!-- start up Server in Docker for integration-test -->
       <plugin>
+        <groupId>com.github.monkeywie</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <id>prepare-autodeploy</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <sourceFile>${project.build.directory}/${project.artifactId}-${project.version}.xar</sourceFile>
+                  <destinationFile>${project.build.directory}/autodeploy/${project.artifactId}-${project.version}.xar</destinationFile>
+                </fileSet>
+              </fileSets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.exist-db.maven.plugins</groupId>
+        <artifactId>public-xar-repo-plugin</artifactId>
+        <version>1.2.0</version>
+        <executions>
+          <execution>
+            <id>prepare-autodeploy-deps</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>resolve</goal>
+            </goals>
+            <configuration>
+              <repoUri>http://exist-db.org/exist/apps/public-repo</repoUri>
+              <outputDirectory>${project.build.directory}/autodeploy/</outputDirectory>
+              <existDbVersion>${exist.version}</existDbVersion>
+              <packages>
+                <package>
+                  <abbrev>shared</abbrev>
+                  <version>${shared-resources.version}</version>
+                </package>
+              </packages>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>0.35.0</version>
@@ -264,6 +312,11 @@
                 <ports>
                   <port>8080:8080</port>
                 </ports>
+                <volumes>
+                  <bind>
+                    <volume>${project.build.directory}/autodeploy:/exist/autodeploy</volume>
+                  </bind>
+                </volumes>
                 <wait>
                   <log>Server has started, listening on</log>
                   <time>120000</time>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <project.build.target>1.8</project.build.target>
 
     <exist.version>5.3.0-SNAPSHOT</exist.version>
-    <shared-resources.version>0.8.2</shared-resources.version>
+    <shared-resources.version>0.8.4</shared-resources.version>
     <node.version>v10.22.1</node.version>
     <npm.version>6.14.6</npm.version>
 

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -14,7 +14,7 @@
   <category id="apps">Applications</category>
   <category id="doc">Documentation</category>
   <dependency processor="http://exist-db.org" semver-min="${exist.version}"/>
-  <dependency package="http://exist-db.org/apps/shared" semver-min="0.8.2"/>
+  <dependency package="http://exist-db.org/apps/shared" semver-min="${shared-resources.version}"/>
   <prepare>pre-install.xql</prepare>
   <changelog>
     <change xmlns="http://exist-db.org/xquery/repo" version="5.2.0">


### PR DESCRIPTION
@joewiz This is the missing commit that we discussed on the call this evening.

Actually two commits now, as I later found a problem (via these integration tests) with the docs declaring a dependency on `shared-resources` 0.8.2. It turns out that shared-resources 0.8.2 is not compatible with eXist-db 5.x.x due to its use of old style Map syntax, so I bumped the version of the dependency to 0.8.4.