### PR TITLE
fix(cypress): revert new projectID

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,6 +8,5 @@
   "pluginsFile": "src/test/cypress/plugins/index.js",
   "screenshotsFolder": "src/test/cypress/screenshots",
   "supportFile": "src/test/cypress/support/index.js",
-  "videosFolder": "src/test/cypress/videos",
-  "projectId": "h8zx19"
+  "videosFolder": "src/test/cypress/videos"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -9,5 +9,5 @@
   "screenshotsFolder": "src/test/cypress/screenshots",
   "supportFile": "src/test/cypress/support/index.js",
   "videosFolder": "src/test/cypress/videos",
-  "projectId": "wgr8uu"
+  "projectId": "h8zx19"
 }


### PR DESCRIPTION
the link on the readme takes you to the old dashboard, which is part of our the FOSS plan cypress has granted the exist-db org, there was no need to open a new org, and we should keep the history of runs on the same dashboard.