### PR TITLE
Fix/datasync article

### DIFF
--- a/src/main/xar-resources/data/datasync/datasync.xml
+++ b/src/main/xar-resources/data/datasync/datasync.xml
@@ -57,8 +57,10 @@
         </sect2>
         <sect2 xml:id="conf.xml">
             <title>configure in conf.xml</title>
-            <para>The first job below will sync at start-up, the second will sync at 2am, <link xlink:href="../scheduler/scheduler.xml">see scheduler</link></para>
-            <programlisting language="xml" xlink:href="listings/existconf.xml"/>
+            <para>Sync at start-up, <link xlink:href="../scheduler/scheduler.xml">see scheduler</link></para>
+            <programlisting language="xml" xlink:href="listings/exist-conf-scheduler-startup.xml"/>
+            <para>Sync at 2am, <link xlink:href="../scheduler/scheduler.xml">see scheduler</link></para>
+            <programlisting language="xml" xlink:href="listings/exist-conf-scheduler-2am.xml"/>
         </sect2>
     </sect1>
 </article>

--- a/src/main/xar-resources/data/datasync/listings/exist-conf-scheduler-2am.xml
+++ b/src/main/xar-resources/data/datasync/listings/exist-conf-scheduler-2am.xml
@@ -1,0 +1,4 @@
+<job class="org.fryske_akademy.exist.jobs.DataSyncTaskCron" type="system" cron-trigger="0 0 2 ? * *">
+  <parameter name="collection" value="xmldb:exist:///db/apps/teidictjson/data"/>
+  <parameter name="datadir" value="/data"/>
+</job>

--- a/src/main/xar-resources/data/datasync/listings/exist-conf-scheduler-startup.xml
+++ b/src/main/xar-resources/data/datasync/listings/exist-conf-scheduler-startup.xml
@@ -1,0 +1,4 @@
+<job class="org.fryske_akademy.exist.jobs.DataSyncTask" type="system" period="10" repeat="0">
+  <parameter name="collection" value="xmldb:exist:///db/apps/teidictjson/data"/>
+  <parameter name="datadir" value="/data"/>
+</job>

--- a/src/main/xar-resources/data/datasync/listings/existconf.xml
+++ b/src/main/xar-resources/data/datasync/listings/existconf.xml
@@ -1,8 +1,0 @@
-<job class="org.fryske_akademy.exist.jobs.DataSyncTask" type="system" period="10" repeat="0" >
-    <parameter name="collection" value="xmldb:exist:///db/apps/teidictjson/data"/>
-    <parameter name="datadir" value="/data"/>
-</job>
-<job class="org.fryske_akademy.exist.jobs.DataSyncTaskCron" type="system" cron-trigger="0 0 2 ? * *" >
-<parameter name="collection" value="xmldb:exist:///db/apps/teidictjson/data"/>
-<parameter name="datadir" value="/data"/>
-</job>

--- a/src/main/xar-resources/data/datasync/listings/mavenconf.xml
+++ b/src/main/xar-resources/data/datasync/listings/mavenconf.xml
@@ -1,5 +1,11 @@
 <dependency>
-    <groupId>org.fryske-akademy</groupId>
-    <artifactId>exist-db-addons</artifactId>
-    <version>2.3</version>
+  <groupId>
+    org.fryske-akademy
+  </groupId>
+  <artifactId>
+    exist-db-addons
+  </artifactId>
+  <version>
+    2.3
+  </version>
 </dependency>

--- a/src/main/xar-resources/data/properties/listings/existconf.xml
+++ b/src/main/xar-resources/data/properties/listings/existconf.xml
@@ -1,4 +1,3 @@
-<module uri="http://exist-db.org/xquery/properties"
-        class="org.fryske_akademy.exist.properties.PropertiesModule">
-    <parameter name="basePath" value="/run/secrets"/>
+<module uri="http://exist-db.org/xquery/properties" class="org.fryske_akademy.exist.properties.PropertiesModule">
+  <parameter name="basePath" value="/run/secrets"/>
 </module>

--- a/src/main/xar-resources/data/properties/listings/mavenconf.xml
+++ b/src/main/xar-resources/data/properties/listings/mavenconf.xml
@@ -1,5 +1,11 @@
 <dependency>
-    <groupId>org.fryske-akademy</groupId>
-    <artifactId>exist-db-addons</artifactId>
-    <version>2.3</version>
+  <groupId>
+    org.fryske-akademy
+  </groupId>
+  <artifactId>
+    exist-db-addons
+  </artifactId>
+  <version>
+    2.3
+  </version>
 </dependency>


### PR DESCRIPTION
One of the listings in the data sync article had two elements at its root.

With this PR applied the listing is split into two, which also makes the article a little nicer to read.

`/exist/apps/doc/datasync.xml`

This also fixes the error that is thrown when documentation app is installed via upload in package manager

<img width="627" alt="Screenshot 2021-06-10 at 00 20 29" src="https://user-images.githubusercontent.com/657222/121488295-3cc8b100-c9d3-11eb-874c-5146a0eb78c0.png">
