### PR TITLE
Generated resources should go into target dir and not src dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,3 @@ src/test/cypress/screenshots/**/*.png
 github-report.html
 node_modules/*
 node/*
-src/main/xar-resources/resources/scripts/*.min.*
-src/main/xar-resources/resources/styles/*.min.*
-src/main/xar-resources/resources/styles/*.map

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -20,30 +20,30 @@ var settings = {
 
 var paths = {
   input: 'src/main/frontend/',
-  output: 'src/main/xar-resources/resources/',
+  output: 'target/generated-resources/gulp/xar-resources/resources/',
   scripts: {
     input: 'src/main/frontend/javascript/*',
     polyfills: '.polyfill.js',
-    output: 'src/main/xar-resources/resources/scripts/'
+    output: 'target/generated-resources/gulp/xar-resources/resources/scripts/'
   },
   styles: {
     input: 'src/main/frontend/sass/*.{scss,sass}',
-    output: 'src/main/xar-resources/resources/styles/'
+    output: 'target/generated-resources/gulp/xar-resources/resources/styles/'
   },
   svgs: {
     input: 'src/main/frontend/img/*.svg',
-    output: 'src/main/xar-resources/resources/images/'
+    output: 'target/generated-resources/gulp/xar-resources/resources/images/'
   },
   copy: {
     input: 'src/main/frontend/copy/**',
-    output: 'src/main/xar-resources/resources/'
+    output: 'target/generated-resources/gulp/xar-resources/resources/'
   },
   vendor: {
     input: 'node_modules/',
-    output: 'src/main/xar-resources/resources/'
+    output: 'target/generated-resources/gulp/xar-resources/resources/'
   },
   fonts: {
-    output: 'src/main/xar-resources/resources/fonts/'
+    output: 'target/generated-resources/gulp/xar-resources/resources/fonts/'
   },
   xml: {
     listings: 'src/main/xar-resources/data/*/listings/*.xml',

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -20,30 +20,30 @@ var settings = {
 
 var paths = {
   input: 'src/main/frontend/',
-  output: 'target/generated-resources/gulp/xar-resources/resources/',
+  output: 'target/generated-resources/frontend/xar-resources/resources/',
   scripts: {
     input: 'src/main/frontend/javascript/*',
     polyfills: '.polyfill.js',
-    output: 'target/generated-resources/gulp/xar-resources/resources/scripts/'
+    output: 'target/generated-resources/frontend/xar-resources/resources/scripts/'
   },
   styles: {
     input: 'src/main/frontend/sass/*.{scss,sass}',
-    output: 'target/generated-resources/gulp/xar-resources/resources/styles/'
+    output: 'target/generated-resources/frontend/xar-resources/resources/styles/'
   },
   svgs: {
     input: 'src/main/frontend/img/*.svg',
-    output: 'target/generated-resources/gulp/xar-resources/resources/images/'
+    output: 'target/generated-resources/frontend/xar-resources/resources/images/'
   },
   copy: {
     input: 'src/main/frontend/copy/**',
-    output: 'target/generated-resources/gulp/xar-resources/resources/'
+    output: 'target/generated-resources/frontend/xar-resources/resources/'
   },
   vendor: {
     input: 'node_modules/',
-    output: 'target/generated-resources/gulp/xar-resources/resources/'
+    output: 'target/generated-resources/frontend/xar-resources/resources/'
   },
   fonts: {
-    output: 'target/generated-resources/gulp/xar-resources/resources/fonts/'
+    output: 'target/generated-resources/frontend/xar-resources/resources/fonts/'
   },
   xml: {
     listings: 'src/main/xar-resources/data/*/listings/*.xml',

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -77,6 +77,19 @@
     </fileSet>
     <fileSet>
       <directory>${project.build.outputDirectory}</directory>
+      <excludes>
+        <!--
+          These are not needed from this fileSet,
+          instead they are taken from the fileSet
+          of the Gulp transform output in ${project.build.directory}/generated-resources/gulp/xar-resources
+          see the fileSet below.
+        -->
+        <exclude>**.js</exclude>
+        <exclude>**.css</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/generated-resources/gulp/xar-resources</directory>
     </fileSet>
   </fileSets>
 

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -81,7 +81,7 @@
         <!--
           These are not needed from this fileSet,
           instead they are taken from the fileSet
-          of the Gulp transform output in ${project.build.directory}/generated-resources/gulp/xar-resources
+          of the Gulp transform output in ${project.build.directory}/generated-resources/frontend/xar-resources
           see the fileSet below.
         -->
         <exclude>**.js</exclude>
@@ -89,7 +89,7 @@
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>${project.build.directory}/generated-resources/gulp/xar-resources</directory>
+      <directory>${project.build.directory}/generated-resources/frontend/xar-resources</directory>
     </fileSet>
   </fileSets>
 


### PR DESCRIPTION
In the end an easy fix, the behaviour is already supported by the `kuberam-expath-plugin`.

Closes https://github.com/eXist-db/documentation/issues/633