### PR TITLE
XML Pretty-print should be an editorial concern not enforced during the build

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -199,22 +199,28 @@ var lintScripts = function(done) {
   done()
 }
 
-// pretty print all xml listings
-// articles not yet decided
-var prettyXml = function(done) {
-  src(paths.xml.listings, { base: "./" })
-  .pipe(muxml({
-    stripComments: false,
-    stripCdata: false,
-    stripInstruction: false,
-    saxOptions: {
-      trim: true,
-      normalize: true
-    }
-  }))
-    .pipe(dest("./"))
-    // Signal completion
-    done()
+function prettyPrintXml(xmlSrcPath, xmlTargetPath, done) {
+  src(xmlSrcPath, { base: "./" })
+      .pipe(muxml({
+        stripComments: false,
+        stripCdata: false,
+        stripInstruction: false,
+        saxOptions: {
+          trim: true,
+          normalize: true
+        }
+      }))
+      .pipe(dest(xmlTargetPath))
+  // Signal completion
+  done()
+}
+
+var prettyPrintListingsXml = function(done) {
+  prettyPrintXml(paths.xml.listings, "./", done)
+}
+
+var prettyPrintArticlesXml = function(done) {
+  prettyPrintXml(paths.xml.articles, "./", done)
 }
 
 // Process, lint, and minify Sass files
@@ -351,7 +357,13 @@ exports.default = series(
     buildStyles,
     buildSVGs,
     copyFiles,
-    buildPack,
-    prettyXml
+    buildPack
   )
+)
+
+// Pretty Print XML task
+// gulp
+exports.prettyPrintXml = parallel(
+    prettyPrintArticlesXml,
+    prettyPrintListingsXml
 )


### PR DESCRIPTION
Some of the changes suggested by Pretty-print are not very good.
Therefore I think it is better to have the option to run Pretty-print, but not to enforce it as part of the build. It was previously only enforced on code-listing and not articles, however the suggestions it was making for the code-listings would actually made their formatting worse; therefore it is best to leave it to the discretion of the Editor.