### PR TITLE
force mvn release plugin to use credentials from .m2/settings.xml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <npm.version>6.14.13</npm.version>
 
     <package-name>http://exist-db.org/apps/doc</package-name>
+    <project.scm.id>github</project.scm.id>
   </properties>
 
   <reporting>


### PR DESCRIPTION
force mvn release plugin to use credentials from .m2/settings.xml  >  server.id = github