### PR TITLE
Remove phrase from 1st issue thank you template which suggests the user erred

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,7 +4,7 @@
 
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: >
-  Thanks for opening your first issue here! Be sure to follow the issue template!
+  Thanks for opening your first issue here!
 
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 


### PR DESCRIPTION
To a user who has just submitted their first issue, the phrase "Be sure to follow the issue template!" reads as if the user failed to follow the template.