### PR TITLE
add lowercase-expended-term

### DIFF
--- a/src/main/xar-resources/data/lucene/listings/listing-48.txt
+++ b/src/main/xar-resources/data/lucene/listings/listing-48.txt
@@ -5,6 +5,7 @@ let $options :=
         <phrase-slop>1</phrase-slop>
         <leading-wildcard>no</leading-wildcard>
         <filter-rewrite>yes</filter-rewrite>
+        <lowercase-expanded-terms>yes</lowercase-expanded-terms>
     </options>
 return
     //SPEECH[ft:query(., $query, $options)]

--- a/src/main/xar-resources/data/lucene/lucene.xml
+++ b/src/main/xar-resources/data/lucene/lucene.xml
@@ -883,7 +883,7 @@
                 <varlistentry>
                     <term> <code>lowercase-expanded-terms</code> </term>
                     <listitem>
-                        <para>User as An option in <code>ft:query</code> to set whether expanded terms (Analyser input) should be lower-cased,
+                        <para>An option in <code>ft:query</code> to set whether expanded terms (Analyser input) should be lower-cased,
                         When set to <code>yes</code>, any expanded terms selected by a wildcard, regex, or fuzzy query will be lower-cased.
                         Default value is <code>no</code>.</para>
                     </listitem>

--- a/src/main/xar-resources/data/lucene/lucene.xml
+++ b/src/main/xar-resources/data/lucene/lucene.xml
@@ -880,6 +880,15 @@
                             that this can produce very slow queries on big indexes.</para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term> <code>lowercase-expanded-terms</code> </term>
+                    <listitem>
+                        <para>Key used to set whether expanded terms should be lower-cased,
+                        <code>LOWERCASE_EXPANDED_TERMS</code> when set to <code>yes</code> automatically lowercases wildcard, regex and fuzzy queries.
+                        Default value is <code>no</code>.
+                        </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </sect2>
     </sect1>

--- a/src/main/xar-resources/data/lucene/lucene.xml
+++ b/src/main/xar-resources/data/lucene/lucene.xml
@@ -883,8 +883,9 @@
                 <varlistentry>
                     <term> <code>lowercase-expanded-terms</code> </term>
                     <listitem>
-                        <para>An option in <code>ft:query</code> to set whether expanded terms (Analyser input) should be lower-cased,
-                        When set to <code>yes</code>, any expanded terms selected by a wildcard, regex, or fuzzy query will be lower-cased.
+                        <para>An option used to set whether the terms in wildcard, prefix, fuzzy, or range queries should be
+                        automatically lower-cased or left in their original case. 
+                        When set to <code>yes</code>, query terms are lower-cased (i.e., as if <code>fn:lower-case()</code> were applied to the query string).
                         Default value is <code>no</code>.</para>
                     </listitem>
                 </varlistentry>

--- a/src/main/xar-resources/data/lucene/lucene.xml
+++ b/src/main/xar-resources/data/lucene/lucene.xml
@@ -883,10 +883,9 @@
                 <varlistentry>
                     <term> <code>lowercase-expanded-terms</code> </term>
                     <listitem>
-                        <para>Key used to set whether expanded terms should be lower-cased,
-                        <code>LOWERCASE_EXPANDED_TERMS</code> when set to <code>yes</code> automatically lowercases wildcard, regex and fuzzy queries.
-                        Default value is <code>no</code>.
-                        </para>
+                        <para>An option used to set whether expanded terms should be lower-cased.
+                        When set to <code>yes</code>, any expanded terms selected by a wildcard, regex, or fuzzy query will be lower-cased.
+                        Default value is <code>no</code>.</para>
                     </listitem>
                 </varlistentry>
             </variablelist>

--- a/src/main/xar-resources/data/lucene/lucene.xml
+++ b/src/main/xar-resources/data/lucene/lucene.xml
@@ -883,7 +883,7 @@
                 <varlistentry>
                     <term> <code>lowercase-expanded-terms</code> </term>
                     <listitem>
-                        <para>An option used to set whether expanded terms should be lower-cased.
+                        <para>User as An option in <code>ft:query</code> to set whether expanded terms (Analyser input) should be lower-cased,
                         When set to <code>yes</code>, any expanded terms selected by a wildcard, regex, or fuzzy query will be lower-cased.
                         Default value is <code>no</code>.</para>
                     </listitem>


### PR DESCRIPTION
Fixes #447 
this PR document the feature add in https://github.com/eXist-db/exist/pull/1378
the wording used for it:
**`lowercase-expanded-terms `**
```
Key used to set whether expanded terms should be lower-cased, LOWERCASE_EXPANDED_TERMS 
when set to yes automatically lowercases wildcard, regex and fuzzy queries.
Default value is no.
```

This open source contribution to the [exist-documentation](https://github.com/eXist-db/documentation) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.