### PR TITLE
state the standard serialization params as unstable 

### DIFF
--- a/src/main/xar-resources/data/xquery/xquery.xml
+++ b/src/main/xar-resources/data/xquery/xquery.xml
@@ -147,14 +147,9 @@
                     <para> <literal>map:merge#2</literal> </para>
                 </listitem>
             </itemizedlist>
-
-            <para>eXist-db supports all standard serialization parameters except the
-                following:</para>
-            <itemizedlist>
-                <listitem>
-                    <para> <literal>item-separator</literal> </para>
-                </listitem>
-            </itemizedlist>
+                <para>eXist-db supports all standard serialization parameters, but some bugs remain in the implementation, as reported by XQuery Test Suite (XQTS). For the internal tests that pass, see the <link condition="_blank"
+            xlink:href="https://github.com/eXist-db/exist/blob/develop/exist-core/src/test/xquery/xquery3/serialize.xql">eXist-db serialization tests</link>. 
+                    </para>
         </sect2>
 
     </sect1>


### PR DESCRIPTION
after the discussion in https://github.com/eXist-db/documentation/issues/436
@adamretter has suggested 
`I think it would be best to remove the list of unsupported serialization parameters from the page as this issue originally suggested. If necessary, we could add a sentence about there being possible bugs, as full XQTS compliance has yet to be reached` 
i updated the unsupported features section to

```
eXist-db does supports all standard serialization 
parameters but there is possible bugs, 
as full XQTS compliance has yet to be reached.
```

This open source contribution to the [exist-documentation](https://github.com/eXist-db/documentation) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.






