### PR TITLE
JMX access over HTTP clarification

### DIFF
--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -167,6 +167,20 @@
             <para>For example, to get a report on current memory usage and running instances, use
                 the following URL:</para>
             <programlisting>http://localhost:8080/exist/status?c=memory&amp;c=instances</programlisting>
+            <note>
+                <para>The JMX information is only accessible via the HTTP interface when either:</para>
+                <itemizedlist>
+                    <listitem>
+                        <para>the client accesses the API on localhost</para>
+                    </listitem>
+                    <listitem>
+                        <para>a valid token is provided when accessing the API from a remote IP address</para>
+                    </listitem>
+                </itemizedlist>
+            </note>
+            <note>
+                <para>Use <link xlink:href="production_web_proxying">a web proxy</link> if you wish to provide this service separately from other eXist applications.</para>
+            </note>
             <para>This returns something like:</para>
             <programlisting language="xml" xlink:href="listings/listing-8.xml"/>
             <para>The different JMX objects in eXist are organized into categories. One or more

--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -5,7 +5,7 @@
     xmlns:xlink="http://www.w3.org/1999/xlink">
     <info>
         <title>Java Management Extensions (JMX)</title>
-        <date>February 2022</date>
+        <date>2022-02</date>
         <keywordset>
             <keyword>java-development</keyword>
             <keyword>operations</keyword>

--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -22,14 +22,12 @@
 
     <sect1 xml:id="enable">
         <title>Enabling the JMX agent</title>
-
-        <para>To enable the platform server on the host virtual machine, pass the following Java system properties:</para>
+        <para>The JMX agent is enabled by default for connections to local processes only: it is not exposed over TCP by default.</para>
+        <para>To enable the platform server on the host virtual machine over TCP, pass the following Java system properties (e.g. as part of the <code>JAVA_OPTS</code> environment variable):</para>
         <programlisting xlink:href="listings/listing-1.txt"/>
         <warning>
             <para>These options make the server publicly accessible. Please check the Oracle <link xlink:href="https://docs.oracle.com/javase/1.5.0/docs/guide/management/agent.html"> JMX documentation</link> for details.</para>
         </warning>
-        <para>The extension can now be activated by passing a <code>-j</code> or <code>-jmx</code> command-line parameter to the eXist start scripts (<literal>client.sh</literal>, <literal>startup.sh</literal> etc.). This parameter must be followed by the port number through which the JMX/RMI connections are enabled, for instance:</para>
-        <programlisting xlink:href="listings/listing-2.txt"/>
     </sect1>
 
     <!-- ================================================================== -->
@@ -46,7 +44,11 @@
             <title>Use JConsole</title>
 
             <para>Use a JMX compliant management console to access the management interfaces. For example, call JConsole, which is included with the JDK:</para>
-            <programlisting>jconsole localhost:1099</programlisting>
+            <programlisting>jconsole</programlisting>
+            <para>When connecting locally, select the entry starting <code>org.codehaus.mojo.appessembler.booter.Appass...</code> under "Local Proccess"</para>
+            <para>When connecting remotely over TVP, provide the hostname and port under "Remote Process", or provide them directly from the command line:</para>
+            <programlisting>jconsole hostname:port</programlisting>
+            <para>You may be presented with a dialogue box stating that a secure connection could not be established: it should be possible to continue with an insecure connection.</para>
             <para>Clicking on the <guimenuitem>MBeans</guimenuitem> tab should show some
                 eXist-specific MBeans below the standard Java MBeans (in the tree component to the
                 left).</para>

--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -46,7 +46,7 @@
             <para>Use a JMX compliant management console to access the management interfaces. For example, call JConsole, which is included with the JDK:</para>
             <programlisting>jconsole</programlisting>
             <para>When connecting locally, select the entry starting <code>org.codehaus.mojo.appessembler.booter.Appass...</code> under "Local Proccess"</para>
-            <para>When connecting remotely over TVP, provide the hostname and port under "Remote Process", or provide them directly from the command line:</para>
+            <para>When connecting remotely over TCP, provide the hostname and port under "Remote Process", or provide them directly from the command line:</para>
             <programlisting>jconsole hostname:port</programlisting>
             <para>You may be presented with a dialogue box stating that a secure connection could not be established: it should be possible to continue with an insecure connection.</para>
             <para>Clicking on the <guimenuitem>MBeans</guimenuitem> tab should show some

--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -36,7 +36,7 @@
 
     <sect1 xml:id="monitoring">
         <title>Monitoring and Management</title>
-        <para>This sections explains how to monitor an eXist instance using common Java tools.</para>
+        <para>This section explains how to monitor an eXist instance using common Java tools.</para>
 
 
 

--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -5,7 +5,7 @@
     xmlns:xlink="http://www.w3.org/1999/xlink">
     <info>
         <title>Java Management Extensions (JMX)</title>
-        <date>2Q19</date>
+        <date>February 2022</date>
         <keywordset>
             <keyword>java-development</keyword>
             <keyword>operations</keyword>

--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -160,7 +160,7 @@
                         <para>the client accesses the API on localhost</para>
                     </listitem>
                     <listitem>
-                        <para>a valid token is provided when accessing the API from a remote IP address. A file containing this token and an example of its use can be found in the eXist data directory at <filename>$(EXIST_HOME)/data/jmxservlet.token</filename>.</para>
+                        <para>a valid token is provided when accessing the API from a remote IP address. A file containing this token and an example of its use can be found in the eXist data directory at <code>$(EXIST_HOME)/data/jmxservlet.token</code>.</para>
                     </listitem>
                 </itemizedlist>
             </note>

--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -5,7 +5,7 @@
     xmlns:xlink="http://www.w3.org/1999/xlink">
     <info>
         <title>Java Management Extensions (JMX)</title>
-        <date>2022-02</date>
+        <date>1Q23</date>
         <keywordset>
             <keyword>java-development</keyword>
             <keyword>operations</keyword>
@@ -14,7 +14,7 @@
 
     <!-- ================================================================== -->
 
-    <para>eXist-db provides access to various management interfaces via Java Management Extensions (JMX). An agent in the Java virtual machine exposes agent services as <emphasis>MBeans</emphasis> that belong to different components running within the virtual machine. A JMX-compliant management application can then connect to the agent through the MBeans and access the available services in a standardized way. </para>
+    <para>eXist-db provides access to various management interfaces via Java Management Extensions (JMX). An agent in the Java Virtual Machine exposes agent services as <emphasis>MBeans</emphasis> that belong to different components running within the Virtual Machine. A JMX-compliant management application can then connect to the agent through the MBeans and access the available services in a standardized way. </para>
     <para>The standard Java installation includes a simple client, JConsole, which will display the eXist-specific services. eXist also provides a command-line client for quick access to server statistics and other information.</para>
     <para>eXist only exposes a limited set of read-only services. Most of them are useful for debugging purposes only.</para>
 
@@ -160,7 +160,7 @@
                         <para>the client accesses the API on localhost</para>
                     </listitem>
                     <listitem>
-                        <para>a valid token is provided when accessing the API from a remote IP address. A file containing this token and an example of its use can be found in the eXist data directory at <code>$(EXIST_HOME)/data/jmxservlet.token</code>.</para>
+                        <para>a valid token is provided when accessing the API from a remote IP address. A file containing this token and an example of its use can be found in the eXist data directory at <code>$EXIST_HOME/data/jmxservlet.token</code>.</para>
                     </listitem>
                 </itemizedlist>
             </note>

--- a/src/main/xar-resources/data/jmx/jmx.xml
+++ b/src/main/xar-resources/data/jmx/jmx.xml
@@ -14,34 +14,21 @@
 
     <!-- ================================================================== -->
 
-    <para>eXist-db provides access to various management interfaces via Java Management Extensions
-        (JMX). An agent in the Java virtual machine exposes agent services as so-called MBeans that
-        belong to different components running within the virtual machine. A JMX-compliant
-        management application can then connect to the agent through the MBeans and access the
-        available services in a standardized way. </para>
-    <para>The standard Java installation includes a simple client, JConsole, which will also display
-        the eXist-specific services. eXist also provides a command-line client for quick access to
-        server statistics and other information.</para>
-    <para>Right now, eXist only exposes a limited set of read-only services. Most of them are useful
-        for debugging purposes only.</para>
+    <para>eXist-db provides access to various management interfaces via Java Management Extensions (JMX). An agent in the Java virtual machine exposes agent services as <emphasis>MBeans</emphasis> that belong to different components running within the virtual machine. A JMX-compliant management application can then connect to the agent through the MBeans and access the available services in a standardized way. </para>
+    <para>The standard Java installation includes a simple client, JConsole, which will display the eXist-specific services. eXist also provides a command-line client for quick access to server statistics and other information.</para>
+    <para>eXist only exposes a limited set of read-only services. Most of them are useful for debugging purposes only.</para>
 
     <!-- ================================================================== -->
 
     <sect1 xml:id="enable">
         <title>Enabling the JMX agent</title>
 
-        <para>To enable the platform server within the host virtual machine, pass the following Java
-            system properties:</para>
+        <para>To enable the platform server on the host virtual machine, pass the following Java system properties:</para>
         <programlisting xlink:href="listings/listing-1.txt"/>
         <warning>
-            <para>These options makes the server publicly accessible. Please check the Oracle <link
-                xlink:href="https://docs.oracle.com/javase/1.5.0/docs/guide/management/agent.html">
-                JMX documentation</link> for details.</para>
+            <para>These options make the server publicly accessible. Please check the Oracle <link xlink:href="https://docs.oracle.com/javase/1.5.0/docs/guide/management/agent.html"> JMX documentation</link> for details.</para>
         </warning>
-        <para>The extension can now be activated by passing a <code>-j</code> or <code>-jmx</code>
-            command-line parameter to the eXist start scripts (<literal>client.sh</literal>,
-            <literal>startup.sh</literal> etc.). This parameter must be followed by the port number
-            through which the JMX/RMI connections are enabled. For instance:</para>
+        <para>The extension can now be activated by passing a <code>-j</code> or <code>-jmx</code> command-line parameter to the eXist start scripts (<literal>client.sh</literal>, <literal>startup.sh</literal> etc.). This parameter must be followed by the port number through which the JMX/RMI connections are enabled, for instance:</para>
         <programlisting xlink:href="listings/listing-2.txt"/>
     </sect1>
 
@@ -49,7 +36,7 @@
 
     <sect1 xml:id="monitoring">
         <title>Monitoring and Management</title>
-        <para>This sections explains how to monitor an exist instant using common java tools.</para>
+        <para>This sections explains how to monitor an eXist instance using common Java tools.</para>
 
 
 
@@ -58,8 +45,7 @@
         <sect2 xml:id="jconsole">
             <title>Use JConsole</title>
 
-            <para>Use a JMX-compliant management console to access the management interfaces. For
-                example, call JConsole, which is included with the JDK:</para>
+            <para>Use a JMX compliant management console to access the management interfaces. For example, call JConsole, which is included with the JDK:</para>
             <programlisting>jconsole localhost:1099</programlisting>
             <para>Clicking on the <guimenuitem>MBeans</guimenuitem> tab should show some
                 eXist-specific MBeans below the standard Java MBeans (in the tree component to the
@@ -174,18 +160,16 @@
                         <para>the client accesses the API on localhost</para>
                     </listitem>
                     <listitem>
-                        <para>a valid token is provided when accessing the API from a remote IP address</para>
+                        <para>a valid token is provided when accessing the API from a remote IP address. A file containing this token and an example of its use can be found in the eXist data directory at <filename>$(EXIST_HOME)/data/jmxservlet.token</filename>.</para>
                     </listitem>
                 </itemizedlist>
             </note>
             <note>
-                <para>Use <link xlink:href="production_web_proxying">a web proxy</link> if you wish to provide this service separately from other eXist applications.</para>
+                <para>Consider using <link xlink:href="production_web_proxying">a web proxy</link> if you wish to provide this service separately from other eXist applications.</para>
             </note>
             <para>This returns something like:</para>
             <programlisting language="xml" xlink:href="listings/listing-8.xml"/>
-            <para>The different JMX objects in eXist are organized into categories. One or more
-                categories can be passed to the servlet in parameter <literal>c</literal>. The
-                following categories are recognized:</para>
+            <para>The different JMX objects in eXist are organized into categories. One or more categories can be passed to the servlet in the URL parameter <literal>c</literal>. The following categories are recognized:</para>
             <variablelist>
                 <varlistentry>
                     <term><code>memory</code></term>
@@ -209,7 +193,7 @@
                 <varlistentry>
                     <term><code>system</code></term>
                     <listitem>
-                        <para>Contains system information: eXist version ...</para>
+                        <para>Contains system information, such as the running eXist version.</para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
This PR addresses incomplete instruction on JMX access over HTTP that could lead to misapprehensions about the security of the service.

fixes #106 

This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.