### PR TITLE
Additional layout fixes

### DIFF
--- a/src/main/frontend/sass/_doc.scss
+++ b/src/main/frontend/sass/_doc.scss
@@ -64,6 +64,8 @@ section dl.dl-horizontal {
   color: var(--bs-danger-text-emphasis);
 }
 
+/* content */
+
 .content {
   color: var(--darktext);
 
@@ -77,6 +79,7 @@ section dl.dl-horizontal {
     font-style: italic;
   }
 
+  /* code listings (syntax highlighted) */
   pre > code {
     background-color: var(--black);
     color: var(--white);
@@ -86,6 +89,7 @@ section dl.dl-horizontal {
     border: thin solid var(--lightgrey);
   }
 
+  /* inline code */
   code {
     background-color: inherit;
     color: inherit;
@@ -177,6 +181,7 @@ section dl.dl-horizontal {
     border: 1px solid var(--grey);
   }
 
+  /* nicer scroll targets */
   a[name] {
     scroll-margin-top: 1rem;
   }

--- a/src/main/frontend/sass/_doc.scss
+++ b/src/main/frontend/sass/_doc.scss
@@ -81,6 +81,9 @@ section dl.dl-horizontal {
     background-color: var(--black);
     color: var(--white);
     font-size: .92em;
+    border-radius: .375rem; /* var(--bs-alert-border-radius) */
+    padding: 1rem; /* var(--bs-alert-padding-y) var(--bs-alert-padding-x) */
+    border: thin solid var(--lightgrey);
   }
 
   code {

--- a/src/main/frontend/sass/_doc.scss
+++ b/src/main/frontend/sass/_doc.scss
@@ -70,12 +70,6 @@ section dl.dl-horizontal {
   section {
     clear: both;
   }
-  table {
-    margin: .5em 1em;
-  }
-  td {
-    padding: 6px 4px;
-  }
   .strong {
     font-weight: bold;
   }

--- a/src/main/frontend/sass/_layout.scss
+++ b/src/main/frontend/sass/_layout.scss
@@ -43,10 +43,11 @@
 
 #poweredby {
   float: right;
-  width: 120px;
-  height: 56px;
+  width: 7.5rem;
+  height: 3.5rem;
   margin-bottom: 1rem;
   background: url(../images/powered-by.svg) no-repeat center;
+  background-size: contain;
 }
 
 
@@ -73,10 +74,6 @@
   }
 }
 
-#copyright {
-  width: 15rem;
-  text-align: right;
-  p {
-    padding: 0;
-  }
+#copyright p {
+  padding: 0;
 }

--- a/src/main/xar-resources/data/devguide_indexes/devguide_indexes.xml
+++ b/src/main/xar-resources/data/devguide_indexes/devguide_indexes.xml
@@ -686,13 +686,15 @@
                 <title/>
 
                 <tgroup cols="4">
-                    <tbody>
+                    <thead>
                         <row>
                             <entry> <para>Field name</para> </entry>
                             <entry> <para>Field type</para> </entry>
                             <entry> <para>Description</para> </entry>
                             <entry> <para>Comments</para> </entry>
                         </row>
+                    </thead>
+                    <tbody>
                         <row>
                             <entry> <para>DOCUMENT_URI</para> </entry>
                             <entry> <para>VARCHAR</para> </entry>

--- a/src/main/xar-resources/data/exist-building/exist-building.xml
+++ b/src/main/xar-resources/data/exist-building/exist-building.xml
@@ -104,6 +104,12 @@
     <table>
       <title>Useful Maven targets</title>
       <tgroup cols="2">
+        <thead>
+            <row>
+              <entry><para>Command</para></entry>
+              <entry><para>Description</para></entry>
+            </row>
+        </thead>
         <tbody>
           <row>
             <entry>
@@ -159,6 +165,12 @@
     <table>
       <title>Useful Maven properties and arguments</title>
       <tgroup cols="2">
+        <thead>
+            <row>
+              <entry><para>Argument</para></entry>
+              <entry><para>Description</para></entry>
+            </row>
+        </thead>
         <tbody>
           <row>
             <entry>

--- a/src/main/xar-resources/data/scheduler/scheduler.xml
+++ b/src/main/xar-resources/data/scheduler/scheduler.xml
@@ -196,13 +196,15 @@
                         <colspec colwidth="25%"/>
                         <colspec colwidth="30%"/>
                         <colspec colwidth="20%"/>
-                        <tbody>
+                        <thead>
                             <row>
                                 <entry> <para>Field Name</para> </entry>
                                 <entry> <para>Mandatory?</para> </entry>
                                 <entry> <para>Allowed Values</para> </entry>
                                 <entry> <para>Allowed Special Characters</para> </entry>
                             </row>
+                        </thead>
+                        <tbody>
                             <row>
                                 <entry> <para>Seconds</para> </entry>
                                 <entry> <para>YES</para> </entry>
@@ -336,11 +338,13 @@
                     <tgroup cols="2">
                         <colspec colwidth="30%"/>
                         <colspec colwidth="70%"/>
-                        <tbody>
+                        <thead>
                             <row>
                                 <entry> <para>Expression</para> </entry>
                                 <entry> <para>Meaning</para> </entry>
                             </row>
+                        </thead>
+                        <tbody>
                             <row>
                                 <entry> <para> <code>0 0 12 * * ? </code> </para> </entry>
                                 <entry> <para> Fire at 12pm (noon) every day </para> </entry>

--- a/src/main/xar-resources/modules/xsl/convert-db5.xsl
+++ b/src/main/xar-resources/modules/xsl/convert-db5.xsl
@@ -132,7 +132,7 @@
 
     <xsl:variable name="spacing" as="xs:string" select="normalize-space((@spacing, 'normal')[1])"/>
     <xsl:call-template name="do-anchor"/>
-    <dl class="row {if ($spacing = 'normal') then 'wide' else ''}">
+    <dl class="{if ($spacing = 'normal') then 'wide' else ''}">
 
       <xsl:for-each select="db5:varlistentry">
         <dt>


### PR DESCRIPTION
- tables have proper headings which also fixes the row backgrounds to start with the brighter color
- definition lists, used in many articles, did overflow their container and thus broke the page layout
- code blocks have rounded edges and a subtle thin border to nicely integrate into the overall page
- fixed the background size of the "powered by" element at the bottom
- add some comments to SCSS