### PR TITLE
build: drop version from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "exist-documentation",
-  "version": "6.1.7-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "exist-documentation",
-  "version": "6.1.7-SNAPSHOT",
   "description": "Documentation package for eXist-db",
   "scripts": {
     "test": "mocha src/test/mocha/ --recursive --exit",

--- a/pom.xml
+++ b/pom.xml
@@ -124,16 +124,6 @@
             <phase>compile</phase>
           </execution>
           <execution>
-            <id>npm version bump</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>compile</phase>
-            <configuration>
-              <arguments>version --no-git-tag-version --allow-same-version=true ${project.version}</arguments>
-            </configuration>
-          </execution>
-          <execution>
             <id>npm install</id>
             <goals>
               <goal>npm</goal>


### PR DESCRIPTION
fixes #876

There is no need to keep track of the package version in package.json.