### PR TITLE
chore(app): decouple processor min version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <project.build.source>21</project.build.source>
     <project.build.target>21</project.build.target>
 
-    <exist.version>${project.version}</exist.version>
+    <exist.version>7.0.0-SNAPSHOT</exist.version>
     <templating.version>1.2.1</templating.version>
     <node.version>v24.15.0</node.version>
     <npm.version>11.12.1</npm.version>


### PR DESCRIPTION
cloes #1243

The coupling of app version setting the minimum required processor version creates more problems than it solves.
The minimum required processor version is now set to 7.0.0-SNAPSHOT.