### PR TITLE
Document jetty.http.maxFormContentSize and jetty.http.maxFormKeys

### DIFF
--- a/src/main/xar-resources/data/advanced-installation/advanced-installation.xml
+++ b/src/main/xar-resources/data/advanced-installation/advanced-installation.xml
@@ -217,6 +217,28 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term> <code>jetty.http.maxFormContentSize</code></term>
+                <listitem>
+                    <para>maximum size (in bytes) of an
+                        <literal>application/x-www-form-urlencoded</literal> request body
+                        before Jetty rejects it with HTTP 400 <emphasis>Unable to parse form
+                            content</emphasis>. Default is 200000 (~200 KB), which matches
+                        Jetty's own default. Raise this when the eXist server receives large
+                        form uploads (eXide editor saves, REST/RESTXQ form-encoded posts,
+                        bulk admin actions).</para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term> <code>jetty.http.maxFormKeys</code></term>
+                <listitem>
+                    <para>maximum number of distinct keys in an
+                        <literal>application/x-www-form-urlencoded</literal> request body.
+                        Default is 1000, matching Jetty's own default. Most deployments will
+                        not need to change this; raise it if you see HTTP 400 form-parsing
+                        failures on requests with very many parameters.</para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term> <code>JAVA_OPTS='-Djetty.host=127.0.0.1 -Djetty.http.port=9999' startup.sh</code>
                 </term>
                 <listitem>


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

Documents two new Jetty system properties added by [eXist-db/exist#6420](https://github.com/eXist-db/exist/pull/6420) (closes [eXist-db/exist#4087](https://github.com/eXist-db/exist/issues/4087)):

- `jetty.http.maxFormContentSize` — default `200000` (bytes). Raises the cap on `application/x-www-form-urlencoded` request bodies before Jetty rejects them with HTTP 400 *Unable to parse form content*. Erik Siegel's original report hit this at 200 KB; the workaround was lost when eXist moved to Jetty 12.
- `jetty.http.maxFormKeys` — default `1000`. Caps the number of distinct keys in a form-encoded body. Same shape as above; exposed for parity with Jetty's own knob.

## Where it lives

Added to the existing `<varlistentry>` list in `advanced-installation.xml#cli-flags`, sitting alongside `jetty.host`, `jetty.http.port`, `jetty.ssl.port`. Same wording style, same `jetty.*` naming convention, same usage pattern (`-Djetty.X.Y=Z`).

## Why this section is the right home

Of the candidates @dizzzz listed in #1247:

- **`advanced-installation.xml#cli-flags`** — ✅ already documents `-Djetty.*` system properties exactly like these
- `troubleshooting.xml#port-conflicts` — no, this is about TCP port collisions
- `production_good_practice.xml#gzip` — no, GZIP-specific
- `deployment.xml#run-stand-alone` / `#binding-address` / `#custom` — no, those cover standalone mode, bind address, and custom servlets respectively
- `upgrading.xml#upgrading-from-source` — no, build-from-source only

## Refs

- eXist-db/exist#6420 (the PR exposing the knobs)
- eXist-db/exist#4087 (the original 2021 bug)
- eXist-db/documentation#1247 (this fits @dizzzz's Jetty-docs review)
